### PR TITLE
Bump version to 0.2.1 — fix failed PyPI publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "outlook-desktop-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "Run this on Windows and get Outlook Desktop as an MCP server. No Graph API, no Entra app registration — just your local Outlook."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
- Bumps version `0.2.0` → `0.2.1` in `pyproject.toml`
- The previous README-only commit was merged to `main` without a version bump, causing PyPI to reject the duplicate version (deploy marked red)

## Next steps
After merging to `preview`, open PR from `preview` → `main` to trigger a successful publish and clear the failed status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)