### PR TITLE
Release 0.2.1 — fix failed PyPI publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "outlook-desktop-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "Run this on Windows and get Outlook Desktop as an MCP server. No Graph API, no Entra app registration — just your local Outlook."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
- Bumps version to `0.2.1` so PyPI accepts the publish
- Fixes the red deployment status caused by the duplicate `0.2.0` version

## Test plan
- [x] Version bumped in `pyproject.toml`
- [ ] Merge triggers GitHub Action → successful PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)