### PR TITLE
Release 0.2.2 — redact personal email from tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "outlook-desktop-mcp"
-version = "0.2.1"
+version = "0.2.2"
 description = "Run this on Windows and get Outlook Desktop as an MCP server. No Graph API, no Entra app registration — just your local Outlook."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/calendar_com_test.py
+++ b/tests/calendar_com_test.py
@@ -139,12 +139,12 @@ def test_create_meeting(outlook):
     appt.Body = "Automated meeting test from calendar COM validation."
     appt.MeetingStatus = 1  # olMeeting
 
-    recipient = appt.Recipients.Add("aaanerud@microsoft.com")
+    recipient = appt.Recipients.Add("user@example.com")
     recipient.Type = 1  # olRequired
     appt.Recipients.ResolveAll()
 
     appt.Send()
-    log(f"  Meeting sent: '{appt.Subject}' to aaanerud@microsoft.com")
+    log(f"  Meeting sent: '{appt.Subject}' to user@example.com")
 
 
 def test_update_event(namespace):

--- a/tests/calendar_mcp_test.py
+++ b/tests/calendar_mcp_test.py
@@ -132,7 +132,7 @@ async def run_tests():
                     "subject": "MCP Calendar Meeting Test",
                     "start": start.strftime("%Y-%m-%d %H:%M"),
                     "end": end.strftime("%Y-%m-%d %H:%M"),
-                    "required_attendees": "aaanerud@microsoft.com",
+                    "required_attendees": "user@example.com",
                     "location": "Virtual via MCP",
                     "body": "Meeting created through MCP calendar tools.",
                 })

--- a/tests/phase1_com_test.py
+++ b/tests/phase1_com_test.py
@@ -71,7 +71,7 @@ def test_filter_unread(namespace):
 def test_send_email(outlook):
     """Test 5: Create and send a test email to self."""
     mail = outlook.CreateItem(0)  # 0 = olMailItem
-    mail.To = "aaanerud@microsoft.com"
+    mail.To = "user@example.com"
     mail.Subject = "Outlook Desktop MCP - COM Test"
     mail.Body = (
         "This is an automated test from the Outlook Desktop MCP COM validation.\n"
@@ -79,7 +79,7 @@ def test_send_email(outlook):
         "\nIf you received this, COM send_email works."
     )
     mail.Send()
-    log("  Email sent to aaanerud@microsoft.com")
+    log("  Email sent to user@example.com")
 
 
 def test_mark_read_unread(namespace):

--- a/tests/phase3_mcp_test.py
+++ b/tests/phase3_mcp_test.py
@@ -139,7 +139,7 @@ async def run_tests():
             log("\n--- Test 6: send_email ---")
             try:
                 result = await session.call_tool("send_email", {
-                    "to": "aaanerud@microsoft.com",
+                    "to": "user@example.com",
                     "subject": "Outlook Desktop MCP - Phase 3 MCP Test",
                     "body": "Sent through the MCP server via stdio. If you see this, the MCP layer works!",
                 })


### PR DESCRIPTION
## Summary
- Replaced personal email (`aaanerud@microsoft.com`) with `user@example.com` in all test files
- Version bumped to 0.2.2

## Changes
- `tests/calendar_com_test.py` — 2 occurrences replaced
- `tests/calendar_mcp_test.py` — 1 occurrence replaced
- `tests/phase1_com_test.py` — 2 occurrences replaced
- `tests/phase3_mcp_test.py` — 1 occurrence replaced
- `pyproject.toml` — version 0.2.1 → 0.2.2

## Test plan
- [ ] Verify no real email remains in test files
- [ ] Confirm PyPI publish succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)