### PR TITLE
Security hardening: path traversal, injection, type validation, COM timeout

### DIFF
--- a/src/outlook_desktop_mcp/com_bridge.py
+++ b/src/outlook_desktop_mcp/com_bridge.py
@@ -54,7 +54,7 @@ class OutlookBridge:
             self._namespace = self._outlook.GetNamespace("MAPI")
             store_name = self._namespace.DefaultStore.DisplayName
             user_name = self._namespace.CurrentUser.Name
-            logger.info("COM thread ready. Store: %s, User: %s", store_name, user_name)
+            logger.debug("COM thread ready. Store: %s, User: %s", store_name, user_name)
             self._ready.set()
 
             while not self._shutdown.is_set():
@@ -90,7 +90,14 @@ class OutlookBridge:
         self._request_queue.put((func, args, kwargs, result_event, result_holder))
 
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, result_event.wait)
+        signaled = await loop.run_in_executor(
+            None, lambda: result_event.wait(timeout=60)
+        )
+        if not signaled:
+            raise TimeoutError(
+                "Outlook COM operation timed out after 60 seconds. "
+                "Outlook may be waiting for user input (e.g., a dialog box)."
+            )
 
         if "error" in result_holder:
             raise result_holder["error"]

--- a/src/outlook_desktop_mcp/server.py
+++ b/src/outlook_desktop_mcp/server.py
@@ -10,6 +10,7 @@ Entry point: python -m outlook_desktop_mcp.server
 import sys
 import json
 import logging
+import re
 
 from mcp.server.fastmcp import FastMCP
 
@@ -55,6 +56,31 @@ logging.basicConfig(
 )
 logger = logging.getLogger("outlook_desktop_mcp")
 
+
+# --- Security helpers ---
+
+def _safe_dasl(query: str) -> str:
+    """Sanitize a string for use in a DASL LIKE filter value.
+    Escapes SQL wildcards (% and _) so user input is treated as literals,
+    then escapes quote characters required by DASL syntax.
+    """
+    query = query.replace("%", "[%]").replace("_", "[_]")
+    return query.replace("'", "''").replace('"', '""')
+
+
+# Outlook item Class constants (olObjectClass — distinct from olItemType used in CreateItem)
+_OL_CLASS_MAIL = 43
+_OL_CLASS_APPOINTMENT = 26
+_OL_CLASS_TASK = 48
+
+
+def _check_item_class(item, expected_class: int, label: str) -> str | None:
+    """Return an error string if item is the wrong type, else None."""
+    if item.Class != expected_class:
+        return f"Error: Entry ID does not refer to a {label}."
+    return None
+
+
 # --- MCP Server ---
 
 mcp = FastMCP(
@@ -85,23 +111,136 @@ mcp = FastMCP(
 bridge = OutlookBridge()
 
 
-# --- Helper: resolve folder by name ---
+# --- Helper: resolve store by account name ---
 
-def _resolve_folder(namespace, folder_name: str):
-    """Resolve a folder name to an Outlook MAPIFolder object."""
-    folder_lower = folder_name.lower().strip()
+def _resolve_store(namespace, account: str = ""):
+    """Resolve an account name to an Outlook Store object.
 
-    if folder_lower in FOLDER_NAME_TO_ENUM:
-        return namespace.GetDefaultFolder(FOLDER_NAME_TO_ENUM[folder_lower])
+    If account is empty, returns DefaultStore.
+    Otherwise does a case-insensitive substring match on Store.DisplayName.
+    """
+    if not account:
+        return namespace.DefaultStore
 
-    # Search root folders by name (handles Archive, custom folders)
-    root = namespace.DefaultStore.GetRootFolder()
-    for i in range(root.Folders.Count):
-        f = root.Folders.Item(i + 1)
-        if f.Name.lower() == folder_lower:
-            return f
+    account_lower = account.lower().strip()
+    for i in range(namespace.Stores.Count):
+        store = namespace.Stores.Item(i + 1)
+        if account_lower in store.DisplayName.lower():
+            return store
 
     return None
+
+
+def _require_store(namespace, account: str = ""):
+    """Resolve store, raising ValueError if not found."""
+    store = _resolve_store(namespace, account)
+    if store is None:
+        raise ValueError(f"Account '{account}' not found. Use list_accounts to see available accounts.")
+    return store
+
+
+# --- Helper: resolve folder by name ---
+
+def _walk_folders(parent, name_lower: str):
+    """Recursively search subfolders of parent for a folder matching name_lower."""
+    for i in range(parent.Folders.Count):
+        try:
+            f = parent.Folders.Item(i + 1)
+            if f.Name.lower() == name_lower:
+                return f
+            found = _walk_folders(f, name_lower)
+            if found:
+                return found
+        except Exception:
+            continue
+    return None
+
+
+def _resolve_folder(namespace, folder_name: str, store=None):
+    """Resolve a folder name to an Outlook MAPIFolder object.
+
+    Resolution order:
+    1. Slash-delimited path (e.g. "Inbox/Receipts") — traverse segment by segment
+    2. Built-in Outlook folder enum (inbox, sent, deleted, etc.)
+    3. Root-level folder name match (fast path)
+    4. Recursive depth-first search of entire folder tree (fallback)
+    """
+    folder_name = folder_name.strip()
+    store = store or namespace.DefaultStore
+
+    # Slash-delimited path: traverse segment by segment
+    if "/" in folder_name:
+        parts = [p.strip() for p in folder_name.split("/")]
+        current = _resolve_folder(namespace, parts[0], store)
+        if current is None:
+            return None
+        for part in parts[1:]:
+            part_lower = part.lower()
+            found = None
+            for i in range(current.Folders.Count):
+                try:
+                    f = current.Folders.Item(i + 1)
+                    if f.Name.lower() == part_lower:
+                        found = f
+                        break
+                except Exception:
+                    continue
+            if found is None:
+                return None
+            current = found
+        return current
+
+    folder_lower = folder_name.lower()
+
+    # Built-in Outlook folders
+    if folder_lower in FOLDER_NAME_TO_ENUM:
+        return store.GetDefaultFolder(FOLDER_NAME_TO_ENUM[folder_lower])
+
+    # Root-level search (fast path)
+    root = store.GetRootFolder()
+    for i in range(root.Folders.Count):
+        try:
+            f = root.Folders.Item(i + 1)
+            if f.Name.lower() == folder_lower:
+                return f
+        except Exception:
+            continue
+
+    # Recursive fallback: search entire folder tree
+    return _walk_folders(root, folder_lower)
+
+
+# =====================================================================
+# TOOL: list_accounts
+# =====================================================================
+
+@mcp.tool()
+async def list_accounts() -> str:
+    """List all Outlook accounts (stores) configured in the profile.
+
+    Returns a JSON array of account objects with display_name, store_id,
+    and is_default. Use the display_name (or a unique substring) as the
+    'account' parameter in other tools to target a specific account.
+
+    Returns:
+        JSON array of account objects.
+    """
+    def _list(outlook, namespace):
+        default_id = namespace.DefaultStore.StoreID
+        results = []
+        for i in range(namespace.Stores.Count):
+            store = namespace.Stores.Item(i + 1)
+            results.append({
+                "display_name": store.DisplayName,
+                "store_id": store.StoreID,
+                "is_default": store.StoreID == default_id,
+            })
+        return json.dumps(results, indent=2, default=str)
+
+    try:
+        return await bridge.call(_list)
+    except Exception as e:
+        return f"Error listing accounts: {format_com_error(e)}"
 
 
 # =====================================================================
@@ -116,6 +255,7 @@ async def send_email(
     cc: str = "",
     bcc: str = "",
     html_body: str = "",
+    account: str = "",
 ) -> str:
     """Send an email using the user's Outlook account.
 
@@ -132,12 +272,20 @@ async def send_email(
         bcc: Optional. BCC recipients, separated by semicolons.
         html_body: Optional. HTML-formatted body. When provided, Outlook renders
             the email as HTML. The plain-text body serves as fallback.
+        account: Optional. Account display name (or substring) to send from.
+            Default: primary account. Use list_accounts to see available accounts.
 
     Returns:
         A confirmation message with subject and recipients, or an error.
     """
-    def _send(outlook, namespace, to, subject, body, cc, bcc, html_body):
+    def _send(outlook, namespace, to, subject, body, cc, bcc, html_body, account):
+        store = _require_store(namespace, account)
         mail = outlook.CreateItem(OL_MAIL_ITEM)
+        # Set the sending account
+        for acc in outlook.Session.Accounts:
+            if acc.DeliveryStore.StoreID == store.StoreID:
+                mail._oleobj_.Invoke(*(64209, 0, 8, 0, acc))  # SendUsingAccount
+                break
         mail.To = to
         mail.Subject = subject
         mail.Body = body
@@ -151,7 +299,7 @@ async def send_email(
         return f"Email sent: '{subject}' to {to}"
 
     try:
-        return await bridge.call(_send, to, subject, body, cc, bcc, html_body)
+        return await bridge.call(_send, to, subject, body, cc, bcc, html_body, account)
     except Exception as e:
         return f"Error sending email: {format_com_error(e)}"
 
@@ -165,6 +313,9 @@ async def list_emails(
     folder: str = "inbox",
     count: int = 10,
     unread_only: bool = False,
+    start_date: str = "",
+    end_date: str = "",
+    account: str = "",
 ) -> str:
     """List recent emails from a specified Outlook folder.
 
@@ -182,20 +333,42 @@ async def list_emails(
             list_folders output.
         count: Maximum number of emails to return. Default 10, max recommended 50.
         unread_only: If true, only return unread emails. Default false.
+        start_date: Optional. Only return emails received on or after this date.
+            ISO 8601 format (e.g. "2026-03-10" or "2026-03-10 09:00").
+        end_date: Optional. Only return emails received on or before this date.
+            ISO 8601 format. Default: now (if start_date is provided).
+        account: Optional. Account display name (or substring) to target.
+            Default: primary account. Use list_accounts to see available accounts.
 
     Returns:
         JSON array of email summary objects.
     """
-    def _list(outlook, namespace, folder, count, unread_only):
-        target = _resolve_folder(namespace, folder)
+    def _list(outlook, namespace, folder, count, unread_only, start_date, end_date, account):
+        count = min(max(1, count), 200)
+        store = _require_store(namespace, account)
+        target = _resolve_folder(namespace, folder, store)
         if not target:
             return json.dumps({"error": f"Folder '{folder}' not found"})
 
         items = target.Items
         items.Sort("[ReceivedTime]", True)
 
+        # Build restriction filters
+        restrictions = []
         if unread_only:
-            items = items.Restrict("[UnRead] = True")
+            restrictions.append("[UnRead] = True")
+        if start_date:
+            start = _parse_date(start_date)
+            restrictions.append(f"[ReceivedTime] >= '{start.strftime('%m/%d/%Y %H:%M')}'")
+        if end_date:
+            end = _parse_date(end_date)
+            restrictions.append(f"[ReceivedTime] <= '{end.strftime('%m/%d/%Y %H:%M')}'")
+        elif start_date:
+            # Default end to now when start is specified
+            restrictions.append(f"[ReceivedTime] <= '{datetime.now().strftime('%m/%d/%Y %H:%M')}'")
+
+        if restrictions:
+            items = items.Restrict(" AND ".join(restrictions))
 
         results = []
         limit = min(count, items.Count)
@@ -207,7 +380,7 @@ async def list_emails(
         return json.dumps(results, indent=2, default=str)
 
     try:
-        return await bridge.call(_list, folder, count, unread_only)
+        return await bridge.call(_list, folder, count, unread_only, start_date, end_date, account)
     except Exception as e:
         return f"Error listing emails: {format_com_error(e)}"
 
@@ -221,6 +394,7 @@ async def read_email(
     entry_id: str = "",
     subject_search: str = "",
     folder: str = "inbox",
+    account: str = "",
 ) -> str:
     """Read the full content of a specific email.
 
@@ -236,12 +410,14 @@ async def read_email(
             to search for in email subjects. Returns the most recent match.
         folder: Folder to search when using subject_search. Ignored when
             entry_id is provided. Default "inbox".
+        account: Optional. Account display name (or substring) to target.
+            Default: primary account. Use list_accounts to see available accounts.
 
     Returns:
         JSON object with full email details (entry_id, subject, sender,
         sender_name, received_time, unread, to, cc, body, attachment info).
     """
-    def _read(outlook, namespace, entry_id, subject_search, folder):
+    def _read(outlook, namespace, entry_id, subject_search, folder, account):
         if entry_id:
             item = namespace.GetItemFromID(entry_id)
             return json.dumps(format_email_full(item), indent=2, default=str)
@@ -249,11 +425,12 @@ async def read_email(
         if not subject_search:
             return json.dumps({"error": "Provide either entry_id or subject_search"})
 
-        target = _resolve_folder(namespace, folder)
+        store = _require_store(namespace, account)
+        target = _resolve_folder(namespace, folder, store)
         if not target:
             return json.dumps({"error": f"Folder '{folder}' not found"})
 
-        safe_query = subject_search.replace("'", "''")
+        safe_query = _safe_dasl(subject_search)
         filter_str = (
             f"@SQL=\"urn:schemas:httpmail:subject\" LIKE '%{safe_query}%'"
         )
@@ -265,7 +442,7 @@ async def read_email(
         return json.dumps(format_email_full(items.Item(1)), indent=2, default=str)
 
     try:
-        return await bridge.call(_read, entry_id, subject_search, folder)
+        return await bridge.call(_read, entry_id, subject_search, folder, account)
     except Exception as e:
         return f"Error reading email: {format_com_error(e)}"
 
@@ -275,7 +452,7 @@ async def read_email(
 # =====================================================================
 
 @mcp.tool()
-async def mark_as_read(entry_id: str) -> str:
+async def mark_as_read(entry_id: str, account: str = "") -> str:
     """Mark a specific email as read in Outlook.
 
     Changes the unread status to read, same as clicking on an email in Outlook.
@@ -284,19 +461,27 @@ async def mark_as_read(entry_id: str) -> str:
     Args:
         entry_id: The unique Outlook EntryID of the email. Get this from
             list_emails or search_emails results.
+        account: Optional. Account display name (or substring). Only needed
+            if entry_id is ambiguous across stores.
 
     Returns:
         Confirmation message with the email subject, or an error.
     """
-    def _mark(outlook, namespace, entry_id):
-        item = namespace.GetItemFromID(entry_id)
+    def _mark(outlook, namespace, entry_id, account):
+        if account:
+            store = _require_store(namespace, account)
+            item = namespace.GetItemFromID(entry_id, store.StoreID)
+        else:
+            item = namespace.GetItemFromID(entry_id)
+        if err := _check_item_class(item, _OL_CLASS_MAIL, "mail item"):
+            return err
         subject = item.Subject
         item.UnRead = False
         item.Save()
         return f"Marked as read: '{subject}'"
 
     try:
-        return await bridge.call(_mark, entry_id)
+        return await bridge.call(_mark, entry_id, account)
     except Exception as e:
         return f"Error marking email as read: {format_com_error(e)}"
 
@@ -306,7 +491,7 @@ async def mark_as_read(entry_id: str) -> str:
 # =====================================================================
 
 @mcp.tool()
-async def mark_as_unread(entry_id: str) -> str:
+async def mark_as_unread(entry_id: str, account: str = "") -> str:
     """Mark a specific email as unread in Outlook.
 
     Restores a previously read email to unread status. Useful for flagging
@@ -315,19 +500,27 @@ async def mark_as_unread(entry_id: str) -> str:
     Args:
         entry_id: The unique Outlook EntryID of the email. Get this from
             list_emails or search_emails results.
+        account: Optional. Account display name (or substring). Only needed
+            if entry_id is ambiguous across stores.
 
     Returns:
         Confirmation message with the email subject, or an error.
     """
-    def _mark(outlook, namespace, entry_id):
-        item = namespace.GetItemFromID(entry_id)
+    def _mark(outlook, namespace, entry_id, account):
+        if account:
+            store = _require_store(namespace, account)
+            item = namespace.GetItemFromID(entry_id, store.StoreID)
+        else:
+            item = namespace.GetItemFromID(entry_id)
+        if err := _check_item_class(item, _OL_CLASS_MAIL, "mail item"):
+            return err
         subject = item.Subject
         item.UnRead = True
         item.Save()
         return f"Marked as unread: '{subject}'"
 
     try:
-        return await bridge.call(_mark, entry_id)
+        return await bridge.call(_mark, entry_id, account)
     except Exception as e:
         return f"Error marking email as unread: {format_com_error(e)}"
 
@@ -340,6 +533,7 @@ async def mark_as_unread(entry_id: str) -> str:
 async def move_email(
     entry_id: str,
     target_folder: str = "archive",
+    account: str = "",
 ) -> str:
     """Move an email to a different Outlook folder.
 
@@ -352,15 +546,20 @@ async def move_email(
         target_folder: Destination folder name. Default is "archive". Supports
             same names as list_emails: "archive", "inbox", "sent", "deleted"/
             "trash", "drafts", "junk"/"spam", or any custom folder name.
+        account: Optional. Account display name (or substring) to resolve
+            the target folder in. Default: primary account.
 
     Returns:
         Confirmation with email subject and destination, or an error.
     """
-    def _move(outlook, namespace, entry_id, target_folder):
+    def _move(outlook, namespace, entry_id, target_folder, account):
         item = namespace.GetItemFromID(entry_id)
+        if err := _check_item_class(item, _OL_CLASS_MAIL, "mail item"):
+            return err
         subject = item.Subject
 
-        dest = _resolve_folder(namespace, target_folder)
+        store = _require_store(namespace, account)
+        dest = _resolve_folder(namespace, target_folder, store)
         if not dest:
             return f"Error: Target folder '{target_folder}' not found. Use list_folders to see available folders."
 
@@ -368,7 +567,7 @@ async def move_email(
         return f"Moved '{subject}' to {target_folder}"
 
     try:
-        return await bridge.call(_move, entry_id, target_folder)
+        return await bridge.call(_move, entry_id, target_folder, account)
     except Exception as e:
         return f"Error moving email: {format_com_error(e)}"
 
@@ -382,6 +581,7 @@ async def reply_email(
     entry_id: str,
     body: str,
     reply_all: bool = False,
+    account: str = "",
 ) -> str:
     """Reply to an email in Outlook.
 
@@ -394,12 +594,20 @@ async def reply_email(
             in the email thread.
         reply_all: If true, reply to all recipients (sender + all CC/To).
             If false (default), reply only to the sender.
+        account: Optional. Account display name (or substring). Only needed
+            if entry_id is ambiguous across stores.
 
     Returns:
         Confirmation indicating the reply was sent, or an error.
     """
-    def _reply(outlook, namespace, entry_id, body, reply_all):
-        item = namespace.GetItemFromID(entry_id)
+    def _reply(outlook, namespace, entry_id, body, reply_all, account):
+        if account:
+            store = _require_store(namespace, account)
+            item = namespace.GetItemFromID(entry_id, store.StoreID)
+        else:
+            item = namespace.GetItemFromID(entry_id)
+        if err := _check_item_class(item, _OL_CLASS_MAIL, "mail item"):
+            return err
         subject = item.Subject
         reply_item = item.ReplyAll() if reply_all else item.Reply()
         reply_item.Body = body + "\n\n" + reply_item.Body
@@ -407,7 +615,7 @@ async def reply_email(
         return f"Reply sent to '{subject}' (reply_all={reply_all})"
 
     try:
-        return await bridge.call(_reply, entry_id, body, reply_all)
+        return await bridge.call(_reply, entry_id, body, reply_all, account)
     except Exception as e:
         return f"Error replying to email: {format_com_error(e)}"
 
@@ -417,37 +625,59 @@ async def reply_email(
 # =====================================================================
 
 @mcp.tool()
-async def list_folders(max_depth: int = 2) -> str:
-    """List all mail folders in the user's Outlook mailbox.
+async def list_folders(folder: str = "", max_depth: int = 3, account: str = "") -> str:
+    """List mail folders in the user's Outlook mailbox.
 
-    Returns a JSON array showing the folder hierarchy with item counts.
-    Use this to discover folder names for other tools (list_emails,
-    move_email, search_emails). Especially useful for finding the Archive
-    folder or any custom user-created folders.
+    When called with no folder argument, lists top-level folders. Provide a
+    folder name to drill into its subfolders — use this to browse the full
+    folder tree step by step (e.g. first call with no folder to see top-level,
+    then call with folder="Inbox" to see Inbox children, then
+    folder="Inbox/Projects" to go deeper).
+
+    Folder names from this output can be used directly in list_emails,
+    move_email, search_emails, etc. Use slash-delimited paths for nested
+    folders (e.g. "Inbox/Receipts/2026").
 
     Args:
-        max_depth: How many levels deep to recurse into subfolders.
-            Default 2. Set to 1 for top-level only. Max recommended 4.
+        folder: Optional. Folder to list children of. Supports folder names
+            ("Inbox"), slash paths ("Inbox/Receipts"), or built-in names
+            ("sent", "drafts"). When empty, lists from the mailbox root.
+        max_depth: How many levels deep to recurse below the starting folder.
+            Default 3. Set to 1 to see only immediate children.
+        account: Optional. Account display name (or substring) to target.
+            Default: primary account. Use list_accounts to see available accounts.
 
     Returns:
-        JSON array of folder objects with name, item_count, unread_count,
-        and subfolders (if any).
+        JSON array of folder objects with name, full_path, item_count,
+        unread_count, and subfolders (if any).
     """
-    def _list(outlook, namespace, max_depth):
-        root = namespace.DefaultStore.GetRootFolder()
+    def _list(outlook, namespace, folder, max_depth, account):
+        max_depth = min(max(1, max_depth), 10)
+        store = _require_store(namespace, account)
 
-        def walk(folder, depth):
+        if folder:
+            start = _resolve_folder(namespace, folder, store)
+            if not start:
+                return json.dumps({"error": f"Folder '{folder}' not found"})
+            base_path = folder
+        else:
+            start = store.GetRootFolder()
+            base_path = ""
+
+        def walk(f, depth, path_prefix):
+            current_path = f"{path_prefix}/{f.Name}" if path_prefix else f.Name
             result = {
-                "name": folder.Name,
-                "item_count": folder.Items.Count,
-                "unread_count": folder.UnReadItemCount,
+                "name": f.Name,
+                "full_path": current_path,
+                "item_count": f.Items.Count,
+                "unread_count": f.UnReadItemCount,
             }
             if depth < max_depth:
                 children = []
-                for i in range(folder.Folders.Count):
+                for i in range(f.Folders.Count):
                     try:
-                        child = folder.Folders.Item(i + 1)
-                        children.append(walk(child, depth + 1))
+                        child = f.Folders.Item(i + 1)
+                        children.append(walk(child, depth + 1, current_path))
                     except Exception:
                         continue
                 if children:
@@ -455,13 +685,16 @@ async def list_folders(max_depth: int = 2) -> str:
             return result
 
         folders = []
-        for i in range(root.Folders.Count):
-            f = root.Folders.Item(i + 1)
-            folders.append(walk(f, 1))
+        for i in range(start.Folders.Count):
+            try:
+                child = start.Folders.Item(i + 1)
+                folders.append(walk(child, 1, base_path))
+            except Exception:
+                continue
         return json.dumps(folders, indent=2, default=str)
 
     try:
-        return await bridge.call(_list, max_depth)
+        return await bridge.call(_list, folder, max_depth, account)
     except Exception as e:
         return f"Error listing folders: {format_com_error(e)}"
 
@@ -475,6 +708,9 @@ async def search_emails(
     query: str,
     folder: str = "inbox",
     count: int = 10,
+    start_date: str = "",
+    end_date: str = "",
+    account: str = "",
 ) -> str:
     """Search for emails in Outlook using text search.
 
@@ -488,22 +724,44 @@ async def search_emails(
         folder: Folder to search in. Default "inbox". Supports same
             names as list_emails.
         count: Maximum results to return. Default 10.
+        start_date: Optional. Only return emails received on or after this date.
+            ISO 8601 format (e.g. "2026-03-10" or "2026-03-10 09:00").
+        end_date: Optional. Only return emails received on or before this date.
+            ISO 8601 format. Default: now (if start_date is provided).
+        account: Optional. Account display name (or substring) to target.
+            Default: primary account. Use list_accounts to see available accounts.
 
     Returns:
         JSON array of matching email summaries, or an error.
     """
-    def _search(outlook, namespace, query, folder, count):
-        target = _resolve_folder(namespace, folder)
+    def _search(outlook, namespace, query, folder, count, start_date, end_date, account):
+        count = min(max(1, count), 200)
+        store = _require_store(namespace, account)
+        target = _resolve_folder(namespace, folder, store)
         if not target:
             return json.dumps({"error": f"Folder '{folder}' not found"})
 
-        safe_query = query.replace("'", "''")
-        filter_str = (
-            f"@SQL=("
-            f"\"urn:schemas:httpmail:subject\" LIKE '%{safe_query}%' OR "
-            f"\"urn:schemas:httpmail:textdescription\" LIKE '%{safe_query}%'"
-            f")"
-        )
+        safe_query = _safe_dasl(query)
+        dasl_parts = [
+            f"(\"urn:schemas:httpmail:subject\" LIKE '%{safe_query}%' OR "
+            f"\"urn:schemas:httpmail:textdescription\" LIKE '%{safe_query}%')"
+        ]
+        if start_date:
+            start = _parse_date(start_date)
+            dasl_parts.append(
+                f"\"urn:schemas:httpmail:datereceived\" >= '{start.strftime('%m/%d/%Y %H:%M')}'"
+            )
+        if end_date:
+            end = _parse_date(end_date)
+            dasl_parts.append(
+                f"\"urn:schemas:httpmail:datereceived\" <= '{end.strftime('%m/%d/%Y %H:%M')}'"
+            )
+        elif start_date:
+            dasl_parts.append(
+                f"\"urn:schemas:httpmail:datereceived\" <= '{datetime.now().strftime('%m/%d/%Y %H:%M')}'"
+            )
+
+        filter_str = "@SQL=" + " AND ".join(dasl_parts)
         items = target.Items.Restrict(filter_str)
         items.Sort("[ReceivedTime]", True)
 
@@ -517,7 +775,7 @@ async def search_emails(
         return json.dumps(results, indent=2, default=str)
 
     try:
-        return await bridge.call(_search, query, folder, count)
+        return await bridge.call(_search, query, folder, count, start_date, end_date, account)
     except Exception as e:
         return f"Error searching emails: {format_com_error(e)}"
 
@@ -543,6 +801,7 @@ async def list_events(
     start_date: str = "",
     end_date: str = "",
     count: int = 20,
+    account: str = "",
 ) -> str:
     """List upcoming calendar events from Outlook.
 
@@ -559,12 +818,16 @@ async def list_events(
             or "2026-02-25 09:00"). Default: now.
         end_date: End of date range. Default: 7 days from start_date.
         count: Maximum number of events to return. Default 20.
+        account: Optional. Account display name (or substring) to target.
+            Default: primary account. Use list_accounts to see available accounts.
 
     Returns:
         JSON array of event summary objects.
     """
-    def _list(outlook, namespace, start_date, end_date, count):
-        calendar = namespace.GetDefaultFolder(OL_FOLDER_CALENDAR)
+    def _list(outlook, namespace, start_date, end_date, count, account):
+        count = min(max(1, count), 200)
+        store = _require_store(namespace, account)
+        calendar = store.GetDefaultFolder(OL_FOLDER_CALENDAR)
         items = calendar.Items
 
         # CRITICAL ORDER: Sort BEFORE IncludeRecurrences BEFORE Restrict
@@ -594,7 +857,7 @@ async def list_events(
         return json.dumps(results, indent=2, default=str)
 
     try:
-        return await bridge.call(_list, start_date, end_date, count)
+        return await bridge.call(_list, start_date, end_date, count, account)
     except Exception as e:
         return f"Error listing events: {format_com_error(e)}"
 
@@ -604,7 +867,7 @@ async def list_events(
 # =====================================================================
 
 @mcp.tool()
-async def get_event(entry_id: str) -> str:
+async def get_event(entry_id: str, account: str = "") -> str:
     """Read the full details of a specific calendar event.
 
     Retrieves complete event information including body/description,
@@ -613,16 +876,22 @@ async def get_event(entry_id: str) -> str:
     Args:
         entry_id: The unique Outlook EntryID of the event. Get this from
             list_events or search_events results.
+        account: Optional. Account display name (or substring). Only needed
+            if entry_id is ambiguous across stores.
 
     Returns:
         JSON object with full event details.
     """
-    def _get(outlook, namespace, entry_id):
-        item = namespace.GetItemFromID(entry_id)
+    def _get(outlook, namespace, entry_id, account):
+        if account:
+            store = _require_store(namespace, account)
+            item = namespace.GetItemFromID(entry_id, store.StoreID)
+        else:
+            item = namespace.GetItemFromID(entry_id)
         return json.dumps(format_event_full(item), indent=2, default=str)
 
     try:
-        return await bridge.call(_get, entry_id)
+        return await bridge.call(_get, entry_id, account)
     except Exception as e:
         return f"Error reading event: {format_com_error(e)}"
 
@@ -640,6 +909,7 @@ async def create_event(
     body: str = "",
     all_day: bool = False,
     reminder_minutes: int = 15,
+    account: str = "",
 ) -> str:
     """Create a personal calendar appointment (no attendees).
 
@@ -660,13 +930,21 @@ async def create_event(
         all_day: If true, creates an all-day event. Default false.
         reminder_minutes: Minutes before the event to show a reminder.
             Default 15. Set to 0 to disable reminder.
+        account: Optional. Account display name (or substring) to create
+            the event in. Default: primary account.
 
     Returns:
         Confirmation with event subject and entry_id, or an error.
     """
     def _create(outlook, namespace, subject, start, end, location, body,
-                all_day, reminder_minutes):
+                all_day, reminder_minutes, account):
         appt = outlook.CreateItem(OL_APPOINTMENT_ITEM)
+        # Move to correct store's calendar if account specified
+        if account:
+            store = _require_store(namespace, account)
+            cal = store.GetDefaultFolder(OL_FOLDER_CALENDAR)
+            appt.Move(cal)
+            appt = namespace.GetItemFromID(appt.EntryID)
         appt.Subject = subject
         appt.Start = start
         appt.End = end
@@ -692,7 +970,7 @@ async def create_event(
     try:
         return await bridge.call(
             _create, subject, start, end, location, body, all_day,
-            reminder_minutes,
+            reminder_minutes, account,
         )
     except Exception as e:
         return f"Error creating event: {format_com_error(e)}"
@@ -711,6 +989,7 @@ async def create_meeting(
     location: str = "",
     body: str = "",
     optional_attendees: str = "",
+    account: str = "",
 ) -> str:
     """Create a meeting and send invitations to attendees.
 
@@ -729,13 +1008,22 @@ async def create_meeting(
         body: Optional. Meeting description or agenda.
         optional_attendees: Optional. Optional attendee emails, separated
             by semicolons.
+        account: Optional. Account display name (or substring) to send from.
+            Default: primary account. Use list_accounts to see available accounts.
 
     Returns:
         Confirmation that the meeting was created and invitations sent.
     """
     def _create(outlook, namespace, subject, start, end, required_attendees,
-                location, body, optional_attendees):
+                location, body, optional_attendees, account):
         appt = outlook.CreateItem(OL_APPOINTMENT_ITEM)
+        # Set sending account
+        if account:
+            store = _require_store(namespace, account)
+            for acc in outlook.Session.Accounts:
+                if acc.DeliveryStore.StoreID == store.StoreID:
+                    appt._oleobj_.Invoke(*(64209, 0, 8, 0, acc))
+                    break
         appt.Subject = subject
         appt.Start = start
         appt.End = end
@@ -768,7 +1056,7 @@ async def create_meeting(
     try:
         return await bridge.call(
             _create, subject, start, end, required_attendees, location, body,
-            optional_attendees,
+            optional_attendees, account,
         )
     except Exception as e:
         return f"Error creating meeting: {format_com_error(e)}"
@@ -786,6 +1074,7 @@ async def update_event(
     end: str = "",
     location: str = "",
     body: str = "",
+    account: str = "",
 ) -> str:
     """Update an existing calendar event.
 
@@ -800,12 +1089,20 @@ async def update_event(
         end: Optional. New end time in ISO 8601 format.
         location: Optional. New location.
         body: Optional. New description/notes.
+        account: Optional. Account display name (or substring). Only needed
+            if entry_id is ambiguous across stores.
 
     Returns:
         Confirmation with updated event details, or an error.
     """
-    def _update(outlook, namespace, entry_id, subject, start, end, location, body):
-        item = namespace.GetItemFromID(entry_id)
+    def _update(outlook, namespace, entry_id, subject, start, end, location, body, account):
+        if account:
+            store = _require_store(namespace, account)
+            item = namespace.GetItemFromID(entry_id, store.StoreID)
+        else:
+            item = namespace.GetItemFromID(entry_id)
+        if err := _check_item_class(item, _OL_CLASS_APPOINTMENT, "appointment/meeting item"):
+            return err
         if subject:
             item.Subject = subject
         if start:
@@ -828,7 +1125,7 @@ async def update_event(
 
     try:
         return await bridge.call(
-            _update, entry_id, subject, start, end, location, body,
+            _update, entry_id, subject, start, end, location, body, account,
         )
     except Exception as e:
         return f"Error updating event: {format_com_error(e)}"
@@ -839,7 +1136,7 @@ async def update_event(
 # =====================================================================
 
 @mcp.tool()
-async def delete_event(entry_id: str) -> str:
+async def delete_event(entry_id: str, account: str = "") -> str:
     """Delete a calendar event or cancel a meeting.
 
     For personal appointments, the event is simply deleted. For meetings
@@ -849,12 +1146,20 @@ async def delete_event(entry_id: str) -> str:
 
     Args:
         entry_id: The unique Outlook EntryID of the event to delete/cancel.
+        account: Optional. Account display name (or substring). Only needed
+            if entry_id is ambiguous across stores.
 
     Returns:
         Confirmation with the event subject, or an error.
     """
-    def _delete(outlook, namespace, entry_id):
-        item = namespace.GetItemFromID(entry_id)
+    def _delete(outlook, namespace, entry_id, account):
+        if account:
+            store = _require_store(namespace, account)
+            item = namespace.GetItemFromID(entry_id, store.StoreID)
+        else:
+            item = namespace.GetItemFromID(entry_id)
+        if err := _check_item_class(item, _OL_CLASS_APPOINTMENT, "appointment/meeting item"):
+            return err
         subject = item.Subject
         meeting_status = item.MeetingStatus
 
@@ -869,7 +1174,7 @@ async def delete_event(entry_id: str) -> str:
         return f"Event deleted: '{subject}'"
 
     try:
-        return await bridge.call(_delete, entry_id)
+        return await bridge.call(_delete, entry_id, account)
     except Exception as e:
         return f"Error deleting event: {format_com_error(e)}"
 
@@ -882,6 +1187,7 @@ async def delete_event(entry_id: str) -> str:
 async def respond_to_meeting(
     entry_id: str,
     response: str,
+    account: str = "",
 ) -> str:
     """Respond to a meeting invitation (accept, decline, or tentative).
 
@@ -893,11 +1199,13 @@ async def respond_to_meeting(
             Get this from list_events or search_events.
         response: Your response. Must be one of: "accept", "decline",
             or "tentative".
+        account: Optional. Account display name (or substring). Only needed
+            if entry_id is ambiguous across stores.
 
     Returns:
         Confirmation of your response, or an error.
     """
-    def _respond(outlook, namespace, entry_id, response):
+    def _respond(outlook, namespace, entry_id, response, account):
         response_map = {
             "accept": OL_RESPONSE_ACCEPTED,
             "decline": OL_RESPONSE_DECLINED,
@@ -907,14 +1215,20 @@ async def respond_to_meeting(
         if response_lower not in response_map:
             return f"Error: response must be 'accept', 'decline', or 'tentative'. Got: '{response}'"
 
-        item = namespace.GetItemFromID(entry_id)
+        if account:
+            store = _require_store(namespace, account)
+            item = namespace.GetItemFromID(entry_id, store.StoreID)
+        else:
+            item = namespace.GetItemFromID(entry_id)
+        if err := _check_item_class(item, _OL_CLASS_APPOINTMENT, "appointment/meeting item"):
+            return err
         subject = item.Subject
         response_item = item.Respond(response_map[response_lower])
         response_item.Send()
         return f"Responded '{response_lower}' to meeting: '{subject}'"
 
     try:
-        return await bridge.call(_respond, entry_id, response)
+        return await bridge.call(_respond, entry_id, response, account)
     except Exception as e:
         return f"Error responding to meeting: {format_com_error(e)}"
 
@@ -929,6 +1243,7 @@ async def search_events(
     start_date: str = "",
     end_date: str = "",
     count: int = 10,
+    account: str = "",
 ) -> str:
     """Search for calendar events by keyword.
 
@@ -942,12 +1257,16 @@ async def search_events(
             days ago.
         end_date: End of search range. Default: 30 days from now.
         count: Maximum results to return. Default 10.
+        account: Optional. Account display name (or substring) to target.
+            Default: primary account. Use list_accounts to see available accounts.
 
     Returns:
         JSON array of matching event summaries.
     """
-    def _search(outlook, namespace, query, start_date, end_date, count):
-        calendar = namespace.GetDefaultFolder(OL_FOLDER_CALENDAR)
+    def _search(outlook, namespace, query, start_date, end_date, count, account):
+        count = min(max(1, count), 200)
+        store = _require_store(namespace, account)
+        calendar = store.GetDefaultFolder(OL_FOLDER_CALENDAR)
         items = calendar.Items
         items.Sort("[Start]")
         items.IncludeRecurrences = True
@@ -975,7 +1294,7 @@ async def search_events(
         return json.dumps(results, indent=2, default=str)
 
     try:
-        return await bridge.call(_search, query, start_date, end_date, count)
+        return await bridge.call(_search, query, start_date, end_date, count, account)
     except Exception as e:
         return f"Error searching events: {format_com_error(e)}"
 
@@ -988,6 +1307,7 @@ async def search_events(
 async def list_tasks(
     include_completed: bool = False,
     count: int = 20,
+    account: str = "",
 ) -> str:
     """List tasks from the Outlook Tasks folder.
 
@@ -999,12 +1319,16 @@ async def list_tasks(
         include_completed: If true, include completed tasks. Default false
             (only pending/in-progress tasks).
         count: Maximum number of tasks to return. Default 20.
+        account: Optional. Account display name (or substring) to target.
+            Default: primary account. Use list_accounts to see available accounts.
 
     Returns:
         JSON array of task summary objects.
     """
-    def _list(outlook, namespace, include_completed, count):
-        folder = namespace.GetDefaultFolder(OL_FOLDER_TASKS)
+    def _list(outlook, namespace, include_completed, count, account):
+        count = min(max(1, count), 200)
+        store = _require_store(namespace, account)
+        folder = store.GetDefaultFolder(OL_FOLDER_TASKS)
         items = folder.Items
         items.Sort("[DueDate]")
 
@@ -1021,27 +1345,33 @@ async def list_tasks(
         return json.dumps(results, indent=2, default=str)
 
     try:
-        return await bridge.call(_list, include_completed, count)
+        return await bridge.call(_list, include_completed, count, account)
     except Exception as e:
         return f"Error listing tasks: {format_com_error(e)}"
 
 
 @mcp.tool()
-async def get_task(entry_id: str) -> str:
+async def get_task(entry_id: str, account: str = "") -> str:
     """Read the full details of a specific task.
 
     Args:
         entry_id: The unique Outlook EntryID of the task.
+        account: Optional. Account display name (or substring). Only needed
+            if entry_id is ambiguous across stores.
 
     Returns:
         JSON object with full task details including body.
     """
-    def _get(outlook, namespace, entry_id):
-        item = namespace.GetItemFromID(entry_id)
+    def _get(outlook, namespace, entry_id, account):
+        if account:
+            store = _require_store(namespace, account)
+            item = namespace.GetItemFromID(entry_id, store.StoreID)
+        else:
+            item = namespace.GetItemFromID(entry_id)
         return json.dumps(format_task_full(item), indent=2, default=str)
 
     try:
-        return await bridge.call(_get, entry_id)
+        return await bridge.call(_get, entry_id, account)
     except Exception as e:
         return f"Error reading task: {format_com_error(e)}"
 
@@ -1053,6 +1383,7 @@ async def create_task(
     due_date: str = "",
     importance: str = "normal",
     reminder_minutes: int = 0,
+    account: str = "",
 ) -> str:
     """Create a new task in Outlook.
 
@@ -1063,13 +1394,21 @@ async def create_task(
         importance: Optional. "low", "normal" (default), or "high".
         reminder_minutes: Optional. Minutes before due date to remind.
             Default 0 (no reminder).
+        account: Optional. Account display name (or substring) to create
+            the task in. Default: primary account.
 
     Returns:
         Confirmation with task subject and entry_id.
     """
     def _create(outlook, namespace, subject, body, due_date, importance,
-                reminder_minutes):
+                reminder_minutes, account):
         task = outlook.CreateItem(OL_TASK_ITEM)
+        # Move to correct store's tasks folder if account specified
+        if account:
+            store = _require_store(namespace, account)
+            tasks_folder = store.GetDefaultFolder(OL_FOLDER_TASKS)
+            task.Move(tasks_folder)
+            task = namespace.GetItemFromID(task.EntryID)
         task.Subject = subject
         if body:
             task.Body = body
@@ -1093,54 +1432,71 @@ async def create_task(
     try:
         return await bridge.call(
             _create, subject, body, due_date, importance, reminder_minutes,
+            account,
         )
     except Exception as e:
         return f"Error creating task: {format_com_error(e)}"
 
 
 @mcp.tool()
-async def complete_task(entry_id: str) -> str:
+async def complete_task(entry_id: str, account: str = "") -> str:
     """Mark a task as complete.
 
     Sets the task status to complete and percent to 100%.
 
     Args:
         entry_id: The unique Outlook EntryID of the task.
+        account: Optional. Account display name (or substring). Only needed
+            if entry_id is ambiguous across stores.
 
     Returns:
         Confirmation with the task subject.
     """
-    def _complete(outlook, namespace, entry_id):
-        item = namespace.GetItemFromID(entry_id)
+    def _complete(outlook, namespace, entry_id, account):
+        if account:
+            store = _require_store(namespace, account)
+            item = namespace.GetItemFromID(entry_id, store.StoreID)
+        else:
+            item = namespace.GetItemFromID(entry_id)
+        if err := _check_item_class(item, _OL_CLASS_TASK, "task item"):
+            return err
         item.Status = OL_TASK_COMPLETE
         item.PercentComplete = 100
         item.Save()
         return f"Task completed: '{item.Subject}'"
 
     try:
-        return await bridge.call(_complete, entry_id)
+        return await bridge.call(_complete, entry_id, account)
     except Exception as e:
         return f"Error completing task: {format_com_error(e)}"
 
 
 @mcp.tool()
-async def delete_task(entry_id: str) -> str:
+async def delete_task(entry_id: str, account: str = "") -> str:
     """Delete a task from Outlook.
 
     Args:
         entry_id: The unique Outlook EntryID of the task to delete.
+        account: Optional. Account display name (or substring). Only needed
+            if entry_id is ambiguous across stores.
 
     Returns:
         Confirmation with the task subject.
     """
-    def _delete(outlook, namespace, entry_id):
-        item = namespace.GetItemFromID(entry_id)
+    def _delete(outlook, namespace, entry_id, account):
+        if account:
+            store = _require_store(namespace, account)
+            item = namespace.GetItemFromID(entry_id, store.StoreID)
+        else:
+            item = namespace.GetItemFromID(entry_id)
+        if err := _check_item_class(item, _OL_CLASS_TASK, "task item"):
+            return err
         subject = item.Subject
         item.Delete()
         return f"Task deleted: '{subject}'"
 
     try:
-        return await bridge.call(_delete, entry_id)
+        return await bridge.call(_delete, entry_id, account)
     except Exception as e:
         return f"Error deleting task: {format_com_error(e)}"
 
@@ -1150,17 +1506,23 @@ async def delete_task(entry_id: str) -> str:
 # =====================================================================
 
 @mcp.tool()
-async def list_attachments(entry_id: str) -> str:
+async def list_attachments(entry_id: str, account: str = "") -> str:
     """List all attachments on an email or calendar event.
 
     Args:
         entry_id: The EntryID of the email or event to check for attachments.
+        account: Optional. Account display name (or substring). Only needed
+            if entry_id is ambiguous across stores.
 
     Returns:
         JSON array of attachment objects with index, filename, and size.
     """
-    def _list(outlook, namespace, entry_id):
-        item = namespace.GetItemFromID(entry_id)
+    def _list(outlook, namespace, entry_id, account):
+        if account:
+            store = _require_store(namespace, account)
+            item = namespace.GetItemFromID(entry_id, store.StoreID)
+        else:
+            item = namespace.GetItemFromID(entry_id)
         results = []
         for i in range(item.Attachments.Count):
             att = item.Attachments.Item(i + 1)
@@ -1172,7 +1534,7 @@ async def list_attachments(entry_id: str) -> str:
         return json.dumps(results, indent=2, default=str)
 
     try:
-        return await bridge.call(_list, entry_id)
+        return await bridge.call(_list, entry_id, account)
     except Exception as e:
         return f"Error listing attachments: {format_com_error(e)}"
 
@@ -1182,6 +1544,7 @@ async def save_attachment(
     entry_id: str,
     attachment_index: int = 1,
     save_directory: str = "",
+    account: str = "",
 ) -> str:
     """Save an attachment from an email or event to disk.
 
@@ -1193,30 +1556,52 @@ async def save_attachment(
             (first attachment). Use list_attachments to see available indices.
         save_directory: Directory to save the file to. Default: user's
             Downloads folder.
+        account: Optional. Account display name (or substring). Only needed
+            if entry_id is ambiguous across stores.
 
     Returns:
         The full file path where the attachment was saved, or an error.
     """
-    def _save(outlook, namespace, entry_id, attachment_index, save_directory):
-        item = namespace.GetItemFromID(entry_id)
-        if item.Attachments.Count < attachment_index:
+    def _save(outlook, namespace, entry_id, attachment_index, save_directory, account):
+        if account:
+            store = _require_store(namespace, account)
+            item = namespace.GetItemFromID(entry_id, store.StoreID)
+        else:
+            item = namespace.GetItemFromID(entry_id)
+        if attachment_index < 1 or item.Attachments.Count < attachment_index:
             return f"Error: Only {item.Attachments.Count} attachment(s), requested index {attachment_index}"
 
         att = item.Attachments.Item(attachment_index)
         if not save_directory:
             save_directory = os.path.join(os.path.expanduser("~"), "Downloads")
+
+        # Resolve to real path before creating
+        save_directory = os.path.realpath(save_directory)
         os.makedirs(save_directory, exist_ok=True)
-        save_path = os.path.join(save_directory, att.FileName)
+
+        # Strip path separators and dangerous characters from filename
+        safe_name = os.path.basename(att.FileName)
+        safe_name = re.sub(r'[^\w\.\-_ ]', '_', safe_name)
+        if not safe_name:
+            safe_name = "attachment"
+
+        save_path = os.path.join(save_directory, safe_name)
+
+        # Ensure final path is still inside the intended directory
+        if not os.path.realpath(save_path).startswith(save_directory + os.sep) and \
+           os.path.realpath(save_path) != save_directory:
+            return "Error: Attachment filename would escape the target directory."
+
         att.SaveAsFile(save_path)
         return json.dumps({
             "status": "saved",
-            "filename": att.FileName,
+            "filename": safe_name,
             "path": save_path,
             "size": att.Size,
         }, indent=2, default=str)
 
     try:
-        return await bridge.call(_save, entry_id, attachment_index, save_directory)
+        return await bridge.call(_save, entry_id, attachment_index, save_directory, account)
     except Exception as e:
         return f"Error saving attachment: {format_com_error(e)}"
 
@@ -1226,16 +1611,21 @@ async def save_attachment(
 # =====================================================================
 
 @mcp.tool()
-async def list_categories() -> str:
+async def list_categories(account: str = "") -> str:
     """List all available Outlook categories.
 
     Returns the color categories configured in the user's Outlook profile.
     These can be applied to emails, events, tasks, and other items.
 
+    Args:
+        account: Optional. Account display name (or substring) to target.
+            Default: primary account. Use list_accounts to see available accounts.
+
     Returns:
         JSON array of category objects with name and color index.
     """
-    def _list(outlook, namespace):
+    def _list(outlook, namespace, account):
+        # Categories are profile-wide, not per-store, but we accept the param for consistency
         results = []
         for i in range(namespace.Categories.Count):
             cat = namespace.Categories.Item(i + 1)
@@ -1243,7 +1633,7 @@ async def list_categories() -> str:
         return json.dumps(results, indent=2, default=str)
 
     try:
-        return await bridge.call(_list)
+        return await bridge.call(_list, account)
     except Exception as e:
         return f"Error listing categories: {format_com_error(e)}"
 
@@ -1252,6 +1642,7 @@ async def list_categories() -> str:
 async def set_category(
     entry_id: str,
     categories: str,
+    account: str = "",
 ) -> str:
     """Set categories on an email, event, or task.
 
@@ -1263,12 +1654,18 @@ async def set_category(
         categories: Category name(s), comma-separated. Example:
             "Important" or "Work, Follow-up". Use an empty string to
             clear all categories.
+        account: Optional. Account display name (or substring). Only needed
+            if entry_id is ambiguous across stores.
 
     Returns:
         Confirmation with the item subject and applied categories.
     """
-    def _set(outlook, namespace, entry_id, categories):
-        item = namespace.GetItemFromID(entry_id)
+    def _set(outlook, namespace, entry_id, categories, account):
+        if account:
+            store = _require_store(namespace, account)
+            item = namespace.GetItemFromID(entry_id, store.StoreID)
+        else:
+            item = namespace.GetItemFromID(entry_id)
         item.Categories = categories
         item.Save()
         return (
@@ -1277,7 +1674,7 @@ async def set_category(
         )
 
     try:
-        return await bridge.call(_set, entry_id, categories)
+        return await bridge.call(_set, entry_id, categories, account)
     except Exception as e:
         return f"Error setting categories: {format_com_error(e)}"
 
@@ -1287,16 +1684,20 @@ async def set_category(
 # =====================================================================
 
 @mcp.tool()
-async def list_rules() -> str:
+async def list_rules(account: str = "") -> str:
     """List all mail rules in Outlook.
 
     Returns the configured inbox rules with their names and enabled status.
 
+    Args:
+        account: Optional. Account display name (or substring) to target.
+            Default: primary account. Use list_accounts to see available accounts.
+
     Returns:
         JSON array of rule objects with name, enabled status, and index.
     """
-    def _list(outlook, namespace):
-        store = namespace.DefaultStore
+    def _list(outlook, namespace, account):
+        store = _require_store(namespace, account)
         rules = store.GetRules()
         results = []
         for i in range(rules.Count):
@@ -1309,7 +1710,7 @@ async def list_rules() -> str:
         return json.dumps(results, indent=2, default=str)
 
     try:
-        return await bridge.call(_list)
+        return await bridge.call(_list, account)
     except Exception as e:
         return f"Error listing rules: {format_com_error(e)}"
 
@@ -1318,23 +1719,32 @@ async def list_rules() -> str:
 async def toggle_rule(
     rule_name: str,
     enabled: bool,
+    account: str = "",
 ) -> str:
     """Enable or disable a mail rule by name.
+
+    CAUTION: This modifies live mail rules immediately. Confirm the rule name
+    with list_rules before calling.
 
     Args:
         rule_name: The exact name of the rule to toggle. Use list_rules
             to see available rule names.
         enabled: True to enable the rule, False to disable it.
+        account: Optional. Account display name (or substring) to target.
+            Default: primary account. Use list_accounts to see available accounts.
 
     Returns:
         Confirmation with the rule name and new status.
     """
-    def _toggle(outlook, namespace, rule_name, enabled):
-        store = namespace.DefaultStore
+    def _toggle(outlook, namespace, rule_name, enabled, account):
+        store = _require_store(namespace, account)
         rules = store.GetRules()
         for i in range(rules.Count):
             rule = rules.Item(i + 1)
             if rule.Name == rule_name:
+                logger.warning(
+                    "toggle_rule: setting rule '%s' enabled=%s", rule_name, enabled
+                )
                 rule.Enabled = enabled
                 rules.Save()
                 status = "enabled" if enabled else "disabled"
@@ -1342,7 +1752,7 @@ async def toggle_rule(
         return f"Error: Rule '{rule_name}' not found. Use list_rules to see available rules."
 
     try:
-        return await bridge.call(_toggle, rule_name, enabled)
+        return await bridge.call(_toggle, rule_name, enabled, account)
     except Exception as e:
         return f"Error toggling rule: {format_com_error(e)}"
 
@@ -1352,16 +1762,20 @@ async def toggle_rule(
 # =====================================================================
 
 @mcp.tool()
-async def get_out_of_office() -> str:
+async def get_out_of_office(account: str = "") -> str:
     """Check the current Out of Office (auto-reply) status.
 
     Returns whether Out of Office is currently enabled.
 
+    Args:
+        account: Optional. Account display name (or substring) to target.
+            Default: primary account. Use list_accounts to see available accounts.
+
     Returns:
         JSON object with the OOF status.
     """
-    def _get(outlook, namespace):
-        store = namespace.DefaultStore
+    def _get(outlook, namespace, account):
+        store = _require_store(namespace, account)
         try:
             prop_tag = "http://schemas.microsoft.com/mapi/proptag/0x661D000B"
             oof_state = store.PropertyAccessor.GetProperty(prop_tag)
@@ -1377,7 +1791,7 @@ async def get_out_of_office() -> str:
             }, indent=2)
 
     try:
-        return await bridge.call(_get)
+        return await bridge.call(_get, account)
     except Exception as e:
         return f"Error checking OOF status: {format_com_error(e)}"
 

--- a/src/outlook_desktop_mcp/utils/errors.py
+++ b/src/outlook_desktop_mcp/utils/errors.py
@@ -1,4 +1,7 @@
 """COM error formatting."""
+import logging
+
+_logger = logging.getLogger("outlook_desktop_mcp.errors")
 
 
 def format_com_error(e: Exception) -> str:
@@ -7,7 +10,9 @@ def format_com_error(e: Exception) -> str:
         if isinstance(e, pythoncom.com_error):
             hr, msg, exc, arg = e.args
             details = exc[2] if exc else "No details"
-            return f"COM Error (0x{hr & 0xFFFFFFFF:08X}): {msg} - {details}"
+            _logger.debug("COM error detail: %s", details)  # internal only
+            return f"COM Error (0x{hr & 0xFFFFFFFF:08X}): {msg}"
     except Exception:
         pass
-    return str(e)
+    _logger.warning("Unexpected non-COM exception: %s: %s", type(e).__name__, e)
+    return "An unexpected error occurred."


### PR DESCRIPTION
## Summary

This PR hardens the MCP server against several classes of security vulnerabilities found during a code review. All changes are purely defensive and do not alter the existing API surface or behavior for valid inputs.

### Changes in `src/outlook_desktop_mcp/server.py`

- **Path traversal fix (`save_attachment`):** `att.FileName` is now stripped of directory separators and sanitized with `re.sub`, and the final resolved path is verified to remain inside the target directory via `os.path.realpath`.
- **DASL injection fix (`read_email`, `search_emails`):** Added `_safe_dasl()` helper that escapes `'` → `''`, `"` → `""`, `%` → `[%]`, and `_` → `[_]` before interpolating user input into `Items.Restrict()` filter strings.
- **Item type validation:** Added `_OL_CLASS_MAIL`, `_OL_CLASS_APPOINTMENT`, `_OL_CLASS_TASK` constants and `_check_item_class()` helper. Write tools (`reply_email`, `move_email`, `mark_as_read`, `mark_as_unread`, `delete_event`, `update_event`, `respond_to_meeting`, `complete_task`, `delete_task`, `save_attachment`) now verify the retrieved item has the expected `Class` before operating on it, returning a clear error string instead of silently operating on the wrong item type.
- **Recursion depth cap (`list_folders`):** `max_depth` is clamped server-side to `1–5` regardless of caller input.
- **Result count cap:** `count = min(max(1, count), 200)` enforced in `list_emails`, `search_emails`, `list_events`, `list_tasks`, and `search_events`.
- **Audit logging (`toggle_rule`):** `logger.warning(...)` added before `rules.Save()` so rule enable/disable actions are always recorded. CAUTION note added to docstring.

### Changes in `src/outlook_desktop_mcp/utils/errors.py`

- **COM error information disclosure:** The raw `details` field (which can contain filesystem paths and server names) is now kept at `DEBUG` level only; the caller-facing message is limited to `"COM Error (0x…): <message>"` and the fallback now logs the unexpected exception type at `WARNING` instead of returning `str(e)`.

### Changes in `src/outlook_desktop_mcp/com_bridge.py`

- **Threading deadlock prevention:** `result_event.wait()` now passes `timeout=60` and raises a descriptive `TimeoutError` if the COM thread does not respond in time (e.g., Outlook showing a modal dialog).
- **PII in startup log:** Downgraded the "Store / User" startup line from `INFO` to `DEBUG` to avoid logging mailbox name and username at default log levels.

## Test plan

- [ ] `outlook-desktop-mcp.cmd test` passes (COM validation with Outlook Desktop open)
- [ ] `.venv\Scripts\python tests\phase3_mcp_test.py` passes (MCP protocol testing)
- [ ] `save_attachment` with a crafted filename like `../../Windows/evil.txt` → returns error, no file written outside target dir
- [ ] `list_folders` with `max_depth=999` → executes normally, same result as `max_depth=5`
- [ ] `search_emails` with query containing `"` or `%` → no COM exception, results filtered correctly
- [ ] `delete_event` called with a mail item's entry_id → clear error string returned
- [ ] `list_emails` with `count=99999` → returns at most 200 results