### PR TITLE
Guard against COM errors when walking folder tree

### DIFF
--- a/src/outlook_desktop_mcp/server.py
+++ b/src/outlook_desktop_mcp/server.py
@@ -143,7 +143,13 @@ def _require_store(namespace, account: str = ""):
 
 def _walk_folders(parent, name_lower: str):
     """Recursively search subfolders of parent for a folder matching name_lower."""
-    for i in range(parent.Folders.Count):
+    try:
+        # Some Exchange/shared-mailbox folder types raise COMError on .Count;
+        # treat them as empty to avoid crashing the traversal.
+        count = parent.Folders.Count
+    except Exception:
+        return None
+    for i in range(count):
         try:
             f = parent.Folders.Item(i + 1)
             if f.Name.lower() == name_lower:
@@ -164,6 +170,7 @@ def _resolve_folder(namespace, folder_name: str, store=None):
     2. Built-in Outlook folder enum (inbox, sent, deleted, etc.)
     3. Root-level folder name match (fast path)
     4. Recursive depth-first search of entire folder tree (fallback)
+    5. Search folders (virtual/search folders not in regular tree)
     """
     folder_name = folder_name.strip()
     store = store or namespace.DefaultStore
@@ -177,7 +184,11 @@ def _resolve_folder(namespace, folder_name: str, store=None):
         for part in parts[1:]:
             part_lower = part.lower()
             found = None
-            for i in range(current.Folders.Count):
+            try:
+                count = current.Folders.Count
+            except Exception:
+                return None
+            for i in range(count):
                 try:
                     f = current.Folders.Item(i + 1)
                     if f.Name.lower() == part_lower:
@@ -207,7 +218,25 @@ def _resolve_folder(namespace, folder_name: str, store=None):
             continue
 
     # Recursive fallback: search entire folder tree
-    return _walk_folders(root, folder_lower)
+    result = _walk_folders(root, folder_lower)
+    if result:
+        return result
+
+    # Search folders fallback: virtual folders (e.g. "Flagged", "To-Do") are
+    # not in the regular folder tree — access via Store.GetSearchFolders()
+    try:
+        search_folders = store.GetSearchFolders()
+        for i in range(search_folders.Count):
+            try:
+                f = search_folders.Item(i + 1)
+                if f.Name.lower() == folder_lower:
+                    return f
+            except Exception:
+                continue
+    except Exception:
+        pass
+
+    return None
 
 
 # =====================================================================


### PR DESCRIPTION
## Problem

`_walk_folders` and `_resolve_folder` both call `.Folders.Count` directly on folder objects.
Certain Exchange folder types - public folders, some shared mailboxes - throw a `COMError`
on this property, causing the entire folder resolution to crash rather than gracefully
skipping the inaccessible folder.

Additionally, virtual/search folders (e.g. "Flagged Mail", "To-Do") are not part of the
regular folder tree returned by `GetRootFolder()`, so they could never be resolved by name
even though they're valid Outlook folders.

## Changes

- Wrap `.Folders.Count` in `try/except` in both `_walk_folders` and the slash-path traversal
  in `_resolve_folder` - inaccessible folders are treated as empty instead of raising
- Add a 5th resolution step using `Store.GetSearchFolders()` so virtual folders resolve
  correctly alongside regular ones

## Test plan

- Existing tests pass unchanged on a standard Outlook setup
- Manual: on an account with shared/public folders, `list_emails(folder="...")` no longer
  crashes during folder lookup
- Manual: `list_emails(folder="Flagged Mail")` resolves correctly if a Flagged Mail search
  folder exists in the account