### PR TITLE
Fix duplicate OutlookBridge when launched via `python -m`

### DIFF
--- a/src/outlook_desktop_mcp/server.py
+++ b/src/outlook_desktop_mcp/server.py
@@ -12,6 +12,15 @@ import json
 import logging
 import re
 
+# When launched via `python -m outlook_desktop_mcp.server`, runpy loads this
+# file as sys.modules["__main__"] but NOT as sys.modules["outlook_desktop_mcp.server"].
+# Without this alias, tool modules that later do `from outlook_desktop_mcp
+# import server` re-execute this file, creating a second `bridge = OutlookBridge()`
+# distinct from the one main() actually started — every tool call then times
+# out because no COM thread services the duplicate bridge's queue.
+if __name__ == "__main__":
+    sys.modules["outlook_desktop_mcp.server"] = sys.modules["__main__"]
+
 from mcp.server.fastmcp import FastMCP
 
 from outlook_desktop_mcp.com_bridge import OutlookBridge


### PR DESCRIPTION
## Problem

The documented entry point in `server.py` is `python -m outlook_desktop_mcp.server`.
When launched that way, `runpy` registers this file as `sys.modules["__main__"]` but
**not** as `sys.modules["outlook_desktop_mcp.server"]`.

Tool modules later do `from outlook_desktop_mcp import server` (e.g. to access the
`bridge` global). Python finds no cache entry under that dotted name, so `server.py`
is re-executed and a second `bridge = OutlookBridge()` is created — distinct from the
one `main()` started.

`main()` only starts the COM thread on the first bridge. Tool calls reach the
second bridge, requests sit on its queue with no servicer, and every call times
out (default 60s).

## Reproduction

```
py -m outlook_desktop_mcp.server
```

Then call any tool from an MCP client. Calls hang ~60s and surface as a timeout.
A standalone test that prints `id(bridge)` from `main()` and from a tool module
shows two distinct object IDs without the fix, one with it.

## Fix

Inside the `if __name__ == "__main__":` guard, alias the dotted name to `__main__`:

```python
if __name__ == "__main__":
    sys.modules["outlook_desktop_mcp.server"] = sys.modules["__main__"]
```

The guard ensures the alias only runs on the `python -m` launch path; normal
imports of `server` are unaffected.

## Verification

After the fix, tool calls (`list_categories`, `list_folders`, `list_emails`, etc.)
return real Outlook data instead of timing out.

## Scope

Single 9-line addition to `src/outlook_desktop_mcp/server.py`. No behaviour
change for any existing launch path.