### PR TITLE
Fix macOS calendar date filtering

### DIFF
--- a/src/outlook_desktop_mcp/server_mac.py
+++ b/src/outlook_desktop_mcp/server_mac.py
@@ -78,6 +78,69 @@ def _clean(value: str) -> str:
     return "" if v == "missing value" else v
 
 
+def _apple_date_from_parts(parts: list[str], start_index: int) -> datetime | None:
+    """Build a datetime from numeric AppleScript date parts."""
+    try:
+        values = [int(parts[start_index + i].strip()) for i in range(6)]
+        return datetime(*values)
+    except (IndexError, TypeError, ValueError):
+        return None
+
+
+def _parse_range_start(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _parse_range_end(value: str) -> datetime:
+    dt = datetime.fromisoformat(value)
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", value.strip()):
+        return dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+    return dt
+
+
+def _parse_calendar_records(
+    raw: str,
+    start: datetime,
+    end: datetime,
+    count: int,
+    query: str = "",
+) -> list[dict]:
+    query_lower = query.lower()
+    results = []
+    for record in raw.split(RECORD_DELIM):
+        record = record.strip()
+        if not record:
+            continue
+        parts = record.split(DELIM)
+        if len(parts) < 19:
+            continue
+        subject = parts[1].strip() or "(no subject)"
+        if query_lower and query_lower not in subject.lower():
+            continue
+        start_dt = _apple_date_from_parts(parts, 7)
+        end_dt = _apple_date_from_parts(parts, 13)
+        if start_dt and not (start <= start_dt <= end):
+            continue
+        item = {
+            "entry_id": parts[0].strip(),
+            "subject": subject,
+            "start": parts[2].strip(),
+            "end": parts[3].strip(),
+            "location": _clean(parts[4]),
+            "organizer": _clean(parts[5]),
+            "all_day": parts[6].strip().lower() == "true",
+        }
+        if start_dt and end_dt:
+            item["duration"] = int((end_dt - start_dt).total_seconds() / 60)
+        item["_start_dt"] = start_dt or datetime.max
+        results.append(item)
+
+    results.sort(key=lambda item: item["_start_dt"])
+    for item in results:
+        item.pop("_start_dt", None)
+    return results[:count]
+
+
 # --- UI Scraping for New Outlook for Mac ---
 # New Outlook for Mac stores Exchange/M365 mailbox data in the cloud and
 # does NOT expose it through the AppleScript `inbox` keyword (which only
@@ -832,25 +895,24 @@ async def list_events(
     Returns:
         JSON array of event summary objects.
     """
-    start = datetime.fromisoformat(start_date) if start_date else datetime.now()
-    end = datetime.fromisoformat(end_date) if end_date else start + timedelta(days=7)
-
-    # Fetch more than needed, filter by date in Python since AppleScript
-    # whose-clause date filtering can be unreliable in Outlook for Mac.
-    fetch_limit = count * 3  # overfetch to account for out-of-range events
+    count = min(max(1, count), 200)
+    start = _parse_range_start(start_date) if start_date else datetime.now()
+    end = _parse_range_end(end_date) if end_date else start + timedelta(days=7)
 
     script = f'''tell application "Microsoft Outlook"
-    set evts to calendar events
+    set rangeStart to {format_date(start)}
+    set rangeEnd to {format_date(end)}
+    set evts to calendar events whose start time is greater than or equal to rangeStart and start time is less than or equal to rangeEnd
     set evtCount to count of evts
-    set maxFetch to {fetch_limit}
-    if evtCount < maxFetch then set maxFetch to evtCount
     set output to ""
-    repeat with i from 1 to maxFetch
+    repeat with i from 1 to evtCount
         set e to item i of evts
         set eid to id of e
         set esubject to subject of e
-        set estart to start time of e as string
-        set eend to end time of e as string
+        set estartDate to start time of e
+        set eendDate to end time of e
+        set estart to estartDate as string
+        set eend to eendDate as string
         set elocation to ""
         try
             set elocation to location of e
@@ -860,7 +922,7 @@ async def list_events(
             set eorganizer to organizer of e
         end try
         set eallday to all day flag of e
-        set output to output & (eid as text) & "{DELIM}" & esubject & "{DELIM}" & estart & "{DELIM}" & eend & "{DELIM}" & elocation & "{DELIM}" & eorganizer & "{DELIM}" & (eallday as text) & "{RECORD_DELIM}"
+        set output to output & (eid as text) & "{DELIM}" & esubject & "{DELIM}" & estart & "{DELIM}" & eend & "{DELIM}" & elocation & "{DELIM}" & eorganizer & "{DELIM}" & (eallday as text) & "{DELIM}" & (year of estartDate as integer) & "{DELIM}" & (month of estartDate as integer) & "{DELIM}" & (day of estartDate as integer) & "{DELIM}" & (hours of estartDate as integer) & "{DELIM}" & (minutes of estartDate as integer) & "{DELIM}" & (seconds of estartDate as integer) & "{DELIM}" & (year of eendDate as integer) & "{DELIM}" & (month of eendDate as integer) & "{DELIM}" & (day of eendDate as integer) & "{DELIM}" & (hours of eendDate as integer) & "{DELIM}" & (minutes of eendDate as integer) & "{DELIM}" & (seconds of eendDate as integer) & "{RECORD_DELIM}"
     end repeat
     return output
 end tell'''
@@ -870,23 +932,7 @@ end tell'''
         if not raw:
             return json.dumps([])
 
-        results = []
-        for record in raw.split(RECORD_DELIM):
-            record = record.strip()
-            if not record:
-                continue
-            parts = record.split(DELIM)
-            if len(parts) < 7:
-                continue
-            results.append({
-                "entry_id": parts[0].strip(),
-                "subject": parts[1].strip() or "(no subject)",
-                "start": parts[2].strip(),
-                "end": parts[3].strip(),
-                "location": _clean(parts[4]),
-                "organizer": _clean(parts[5]),
-                "all_day": parts[6].strip().lower() == "true",
-            })
+        results = _parse_calendar_records(raw, start, end, count)
         return json.dumps(results, indent=2, default=str)
     except Exception as e:
         return f"Error listing events: {e}"
@@ -1218,20 +1264,24 @@ async def search_events(
     Returns:
         JSON array of matching event summaries.
     """
-    safe_query = escape(query)
+    count = min(max(1, count), 200)
+    start = _parse_range_start(start_date) if start_date else datetime.now() - timedelta(days=30)
+    end = _parse_range_end(end_date) if end_date else datetime.now() + timedelta(days=30)
 
     script = f'''tell application "Microsoft Outlook"
-    set evts to calendar events whose subject contains "{safe_query}"
+    set rangeStart to {format_date(start)}
+    set rangeEnd to {format_date(end)}
+    set evts to calendar events whose start time is greater than or equal to rangeStart and start time is less than or equal to rangeEnd
     set evtCount to count of evts
-    set maxCount to {count}
-    if evtCount < maxCount then set maxCount to evtCount
     set output to ""
-    repeat with i from 1 to maxCount
+    repeat with i from 1 to evtCount
         set e to item i of evts
         set eid to id of e
         set esubject to subject of e
-        set estart to start time of e as string
-        set eend to end time of e as string
+        set estartDate to start time of e
+        set eendDate to end time of e
+        set estart to estartDate as string
+        set eend to eendDate as string
         set elocation to ""
         try
             set elocation to location of e
@@ -1241,7 +1291,7 @@ async def search_events(
             set eorganizer to organizer of e
         end try
         set eallday to all day flag of e
-        set output to output & (eid as text) & "{DELIM}" & esubject & "{DELIM}" & estart & "{DELIM}" & eend & "{DELIM}" & elocation & "{DELIM}" & eorganizer & "{DELIM}" & (eallday as text) & "{RECORD_DELIM}"
+        set output to output & (eid as text) & "{DELIM}" & esubject & "{DELIM}" & estart & "{DELIM}" & eend & "{DELIM}" & elocation & "{DELIM}" & eorganizer & "{DELIM}" & (eallday as text) & "{DELIM}" & (year of estartDate as integer) & "{DELIM}" & (month of estartDate as integer) & "{DELIM}" & (day of estartDate as integer) & "{DELIM}" & (hours of estartDate as integer) & "{DELIM}" & (minutes of estartDate as integer) & "{DELIM}" & (seconds of estartDate as integer) & "{DELIM}" & (year of eendDate as integer) & "{DELIM}" & (month of eendDate as integer) & "{DELIM}" & (day of eendDate as integer) & "{DELIM}" & (hours of eendDate as integer) & "{DELIM}" & (minutes of eendDate as integer) & "{DELIM}" & (seconds of eendDate as integer) & "{RECORD_DELIM}"
     end repeat
     return output
 end tell'''
@@ -1251,23 +1301,7 @@ end tell'''
         if not raw:
             return json.dumps([])
 
-        results = []
-        for record in raw.split(RECORD_DELIM):
-            record = record.strip()
-            if not record:
-                continue
-            parts = record.split(DELIM)
-            if len(parts) < 7:
-                continue
-            results.append({
-                "entry_id": parts[0].strip(),
-                "subject": parts[1].strip() or "(no subject)",
-                "start": parts[2].strip(),
-                "end": parts[3].strip(),
-                "location": _clean(parts[4]),
-                "organizer": _clean(parts[5]),
-                "all_day": parts[6].strip().lower() == "true",
-            })
+        results = _parse_calendar_records(raw, start, end, count, query)
         return json.dumps(results, indent=2, default=str)
     except Exception as e:
         return f"Error searching events: {e}"

--- a/src/outlook_desktop_mcp/utils/applescript_helpers.py
+++ b/src/outlook_desktop_mcp/utils/applescript_helpers.py
@@ -19,11 +19,10 @@ def escape(text: str) -> str:
 def format_date(dt: datetime) -> str:
     """Convert a Python datetime to an AppleScript date string.
 
-    Returns a string like: date "Sunday, March 22, 2026 at 2:00:00 PM"
-    AppleScript parses dates based on the system locale, so we use a
-    locale-friendly format that osascript can interpret.
+    Avoid ISO-like strings such as "2026-03-22 14:00:00": AppleScript may
+    reinterpret them according to the user's date preferences.
     """
-    return f'date "{dt.strftime("%Y-%m-%d %H:%M:%S")}"'
+    return f'date "{dt.day} {dt.strftime("%B %Y at %H:%M:%S")}"'
 
 
 def parse_date(text: str) -> str:

--- a/tests/test_macos_calendar_dates.py
+++ b/tests/test_macos_calendar_dates.py
@@ -1,0 +1,125 @@
+import asyncio
+import json
+import os
+import sys
+import unittest
+from datetime import datetime
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from outlook_desktop_mcp import server_mac
+from outlook_desktop_mcp.utils.applescript_helpers import DELIM, RECORD_DELIM, format_date
+
+
+def _record(entry_id, subject, start_dt, end_dt, location="", organizer="", all_day=False):
+    parts = [
+        entry_id,
+        subject,
+        start_dt.strftime("%A, %d %B %Y at %H:%M:%S"),
+        end_dt.strftime("%A, %d %B %Y at %H:%M:%S"),
+        location,
+        organizer,
+        "true" if all_day else "false",
+        str(start_dt.year),
+        str(start_dt.month),
+        str(start_dt.day),
+        str(start_dt.hour),
+        str(start_dt.minute),
+        str(start_dt.second),
+        str(end_dt.year),
+        str(end_dt.month),
+        str(end_dt.day),
+        str(end_dt.hour),
+        str(end_dt.minute),
+        str(end_dt.second),
+    ]
+    return DELIM.join(parts)
+
+
+class FakeBridge:
+    def __init__(self, raw):
+        self.raw = raw
+        self.script = ""
+
+    async def run(self, script):
+        self.script = script
+        return self.raw
+
+
+class MacCalendarDateTests(unittest.TestCase):
+    def setUp(self):
+        self.original_bridge = server_mac.bridge
+
+    def tearDown(self):
+        server_mac.bridge = self.original_bridge
+
+    def test_format_date_avoids_iso_like_applescript_dates(self):
+        formatted = format_date(datetime(2026, 5, 3, 9, 30, 0))
+
+        self.assertEqual(formatted, 'date "3 May 2026 at 09:30:00"')
+        self.assertNotIn("2026-05-03", formatted)
+
+    def test_list_events_filters_sorts_and_limits_synthetic_records(self):
+        raw = RECORD_DELIM.join([
+            _record(
+                "later",
+                "Later Synthetic Event",
+                datetime(2026, 5, 10, 10, 0, 0),
+                datetime(2026, 5, 10, 11, 0, 0),
+            ),
+            _record(
+                "outside",
+                "Outside Synthetic Event",
+                datetime(2026, 5, 11, 9, 0, 0),
+                datetime(2026, 5, 11, 10, 0, 0),
+            ),
+            _record(
+                "earlier",
+                "Earlier Synthetic Event",
+                datetime(2026, 5, 4, 9, 0, 0),
+                datetime(2026, 5, 4, 10, 0, 0),
+            ),
+        ])
+        fake_bridge = FakeBridge(raw)
+        server_mac.bridge = fake_bridge
+
+        result = asyncio.run(server_mac.list_events("2026-05-03", "2026-05-10", 1))
+        events = json.loads(result)
+
+        self.assertEqual([event["entry_id"] for event in events], ["earlier"])
+        self.assertIn('date "3 May 2026 at 00:00:00"', fake_bridge.script)
+        self.assertIn('date "10 May 2026 at 23:59:59"', fake_bridge.script)
+
+    def test_search_events_applies_query_and_range_synthetic_records(self):
+        raw = RECORD_DELIM.join([
+            _record(
+                "match",
+                "Planning Sync",
+                datetime(2026, 5, 4, 9, 0, 0),
+                datetime(2026, 5, 4, 10, 0, 0),
+            ),
+            _record(
+                "query-miss",
+                "Review",
+                datetime(2026, 5, 5, 9, 0, 0),
+                datetime(2026, 5, 5, 10, 0, 0),
+            ),
+            _record(
+                "range-miss",
+                "Planning Sync",
+                datetime(2026, 5, 11, 9, 0, 0),
+                datetime(2026, 5, 11, 10, 0, 0),
+            ),
+        ])
+        fake_bridge = FakeBridge(raw)
+        server_mac.bridge = fake_bridge
+
+        result = asyncio.run(server_mac.search_events("planning", "2026-05-03", "2026-05-10", 5))
+        events = json.loads(result)
+
+        self.assertEqual([event["entry_id"] for event in events], ["match"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This draft fixes macOS calendar date handling in the AppleScript-backed server:

- avoid ISO-like AppleScript date literals that can be interpreted incorrectly on macOS
- apply date ranges in `list_events`
- apply date ranges in `search_events`
- enforce the requested `count` after filtering and sorting
- treat date-only `end_date` values as the end of that day

Prepared with assistance from Codex CLI 0.128.0.

## Repro

The previous macOS implementation computed `start_date` and `end_date` in `list_events`, but then fetched an unfiltered calendar event list and returned up to `count * 3` records. `search_events` also accepted date range arguments but did not apply them.

Separately, `format_date()` emitted AppleScript date literals like:

```applescript
date "2026-05-03 09:30:00"
```

AppleScript date parsing depends on system date preferences, so this form can be silently reinterpreted.

## Tests

```bash
python -m unittest tests.test_macos_calendar_dates
```

The new tests use synthetic records only and do not require Outlook, mailbox data, calendar data, accounts, local paths, or network access.

## Notes

This is a focused initial fix for the macOS calendar path. It does not claim complete macOS Outlook compatibility.
