### PR TITLE
Add ARM64 Windows support and Outlook OOM prompt guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,20 @@ The server is structured as two parallel implementations with identical tool nam
 ### Windows
 
 - **Outlook Desktop (Classic)** — the `OUTLOOK.EXE` that comes with Microsoft 365 / Office. The new "modern" Outlook (`olk.exe`) does **not** support COM
-- **Python 3.12+**
+- **Python 3.12+** (x64 or ARM64)
 - **Outlook must be running** when the MCP server starts
+
+Both x64 and ARM64 Windows are supported. On ARM64, all dependencies (`pywin32`, `mcp`, `pydantic-core`, `cryptography`, `cffi`, `rpds-py`) have prebuilt `win_arm64` wheels — see the [ARM64 install notes](#arm64-windows) below for the one extra `pip` flag you need.
+
+#### Outlook "Programmatic Access" security prompts
+
+When the MCP server first touches Outlook's COM API, Outlook may show a dialog: *"A program is trying to access email address information stored in Outlook"* (the Object Model Guard / Programmatic Access prompt). This is Outlook's protection against malicious automation.
+
+You have three options:
+
+1. **Click "Allow access for 10 minutes"** every time you start a session. Fine for casual use.
+2. **Get the antivirus status to "Valid"** in *File > Options > Trust Center > Trust Center Settings > Programmatic Access*. When that line reads `Valid`, the "Never warn me about suspicious activity" radio becomes selectable and the prompts go away. On most personal machines with current Defender this works out of the box.
+3. **Apply the registry policy** in [`docs/suppress-outlook-oom-prompts.reg`](docs/suppress-outlook-oom-prompts.reg) — right-click the file > **Merge** in an Administrator session, then restart Outlook. This sets `AdminSecurityMode=3` and approves all `PromptOOM*` categories under `HKLM\Software\Policies\Microsoft\Office\16.0\Outlook\Security`. On Intune/MDM-managed corporate devices this branch may be locked or overwritten by org policy — ask IT to push the equivalent settings via Group Policy if you can't apply it locally.
 
 ### macOS
 
@@ -187,7 +199,7 @@ Each tool constructs a single AppleScript that fetches all needed data in one `o
 
 ## Install from Source
 
-### Windows
+### Windows (x64)
 
 ```bash
 git clone https://github.com/Aanerud/outlook-desktop-mcp.git
@@ -199,6 +211,29 @@ python .venv\Scripts\pywin32_postinstall.py -install
 ```
 
 Register from source using the launcher script:
+
+```bash
+claude mcp add outlook-desktop -- powershell.exe -Command "& 'C:\path\to\outlook-desktop-mcp\outlook-desktop-mcp.cmd' mcp"
+```
+
+### Windows (ARM64)
+
+The `[cli]` extra of `mcp` transitively pulls in `cryptography`, and pip's default resolver may pick a version that lacks a `win_arm64` wheel — which then fails to build because it requires a Rust toolchain plus OpenSSL. Install without the `cli` extra and force wheels-only resolution:
+
+```powershell
+git clone https://github.com/Aanerud/outlook-desktop-mcp.git
+cd outlook-desktop-mcp
+& "C:\Program Files\Python312-arm64\python.exe" -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install --only-binary=:all: pywin32 mcp
+python -m pip install --no-deps -e .
+python .venv\Scripts\pywin32_postinstall.py -install
+```
+
+The base `mcp` package is sufficient for running the stdio server — the `[cli]` extra is only needed for the `mcp` developer CLI tools (`mcp dev`, `mcp inspector`), which aren't used at runtime.
+
+Register from source the same way as x64:
 
 ```bash
 claude mcp add outlook-desktop -- powershell.exe -Command "& 'C:\path\to\outlook-desktop-mcp\outlook-desktop-mcp.cmd' mcp"

--- a/docs/suppress-outlook-oom-prompts.reg
+++ b/docs/suppress-outlook-oom-prompts.reg
@@ -1,0 +1,22 @@
+Windows Registry Editor Version 5.00
+
+; Suppress Outlook "Programmatic Access" security prompts (Object Model Guard).
+;
+; Apply this .reg file as a local Administrator (right-click > Merge), then
+; restart Outlook. Authoritative for Outlook 2016+ / Microsoft 365 Apps.
+;
+; On corporate-managed (Intune/MDM) machines the HKCU\Software\Policies branch
+; is often read-only for the user. The HKLM keys below require an elevated
+; command prompt or admin-level Registry Editor to apply.
+;
+; Value 2 = "automatically approve" for that prompt category.
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Office\16.0\Outlook\Security]
+"AdminSecurityMode"=dword:00000003
+"PromptOOMSend"=dword:00000002
+"PromptOOMAddressBookAccess"=dword:00000002
+"PromptOOMAddressInformationAccess"=dword:00000002
+"PromptOOMMeetingTaskRequestResponse"=dword:00000002
+"PromptOOMResponse"=dword:00000002
+"PromptOOMSaveAs"=dword:00000002
+"PromptOOMFormulaAccess"=dword:00000002


### PR DESCRIPTION
## Summary
- Document the ARM64 Windows install path: drop `mcp[cli]` (which transitively pulls `cryptography`, lacking a `win_arm64` wheel in the version pip resolves to, forcing a Rust source build) and install with `--only-binary=:all:` against base `mcp` + `pywin32`.
- Add a Requirements subsection covering Outlook's Object Model Guard / "Programmatic Access" security prompt with three handling options (manual allow, fix AV registration, apply registry policy).
- Add `docs/suppress-outlook-oom-prompts.reg` for admins to merge into `HKLM\Software\Policies\...\Outlook\Security`.

## Test plan
- [x] Created fresh `.venv` with Python 3.12 ARM64, ran the documented install commands, verified all wheels resolved without a compiler.
- [x] Launched `outlook-desktop-mcp.cmd mcp`, sent a JSON-RPC `initialize` request, confirmed the server responds with the full tool capability set and connects to Outlook via COM on ARM64.
- [ ] Verify on a non-Intune-managed ARM64 machine that the HKLM `.reg` policy suppresses prompts after Outlook restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)