### PR TITLE
Add draft tools: save_draft, list_drafts, read_draft, send_draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ Both permissions are one-time setup — macOS remembers them for future sessions
 |------|:-------:|:-----:|-------------|
 | `send_email` | yes | yes | Send an email with To/CC/BCC, plain text or HTML body |
 | `save_draft` | yes | yes | Save an email to the Drafts folder without sending (human review workflow) |
+| `list_drafts` | yes | yes | List drafts in the Drafts folder with pagination (newest first) |
+| `read_draft` | yes | yes | Read full content of a specific draft by ID (body, recipients, attachments) |
+| `send_draft` | yes | yes | Send an existing draft by ID (moves to Sent Items automatically) |
 | `list_emails` | yes | yes | List recent emails from any folder, with optional unread filter |
 | `read_email` | yes | yes | Read full email content by entry ID or subject search |
 | `search_emails` | yes | yes | Full-text search across email subjects and bodies |
@@ -166,7 +169,7 @@ These tools rely on COM-specific APIs (MAPI property accessors, the Rules object
 | `toggle_rule` | yes | — | Enable or disable a mail rule by name |
 | `get_out_of_office` | yes | — | Check whether Out of Office auto-reply is on or off |
 
-**Total: 30 tools on Windows, 23 tools on macOS.**
+**Total: 33 tools on Windows, 26 tools on macOS.**
 
 ## Architecture Details
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Both permissions are one-time setup — macOS remembers them for future sessions
 | Tool | Windows | macOS | Description |
 |------|:-------:|:-----:|-------------|
 | `send_email` | yes | yes | Send an email with To/CC/BCC, plain text or HTML body |
+| `save_draft` | yes | yes | Save an email to the Drafts folder without sending (human review workflow) |
 | `list_emails` | yes | yes | List recent emails from any folder, with optional unread filter |
 | `read_email` | yes | yes | Read full email content by entry ID or subject search |
 | `search_emails` | yes | yes | Full-text search across email subjects and bodies |
@@ -165,7 +166,7 @@ These tools rely on COM-specific APIs (MAPI property accessors, the Rules object
 | `toggle_rule` | yes | — | Enable or disable a mail rule by name |
 | `get_out_of_office` | yes | — | Check whether Out of Office auto-reply is on or off |
 
-**Total: 29 tools on Windows, 22 tools on macOS.**
+**Total: 30 tools on Windows, 23 tools on macOS.**
 
 ## Architecture Details
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "outlook-desktop-mcp"
-version = "0.3.0"
+version = "0.3.1"
 description = "Outlook Desktop as an MCP server — Windows (COM) and macOS (AppleScript). No Graph API, no Entra app registration — just your local Outlook."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "outlook-desktop-mcp"
-version = "0.3.1"
+version = "0.3.2"
 description = "Outlook Desktop as an MCP server — Windows (COM) and macOS (AppleScript). No Graph API, no Entra app registration — just your local Outlook."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/outlook_desktop_mcp/server.py
+++ b/src/outlook_desktop_mcp/server.py
@@ -368,6 +368,210 @@ async def save_draft(
 
 
 # =====================================================================
+# TOOL 1C: list_drafts
+# =====================================================================
+
+@mcp.tool()
+async def list_drafts(
+    limit: int = 50,
+    offset: int = 0,
+    account: str = "",
+) -> str:
+    """List drafts currently saved in Outlook's Drafts folder.
+
+    Returns a JSON array of draft summaries sorted by last-modified time
+    (newest first). Each summary includes entry_id, subject, to, cc, bcc,
+    last_modified, has_attachments, and a short body_preview (first ~200
+    chars of the plain-text body). Use entry_id with read_draft to load the
+    full body or with send_draft to dispatch the message.
+
+    Args:
+        limit: Maximum number of drafts to return. Default 50, capped at 200.
+        offset: Number of newest drafts to skip before returning results.
+            Useful for pagination. Default 0.
+        account: Optional. Account display name (or substring) to target.
+            Default: primary account. Use list_accounts to see available accounts.
+
+    Returns:
+        JSON array of draft summary objects.
+    """
+    def _list(outlook, namespace, limit, offset, account):
+        limit = min(max(1, limit), 200)
+        offset = max(0, offset)
+        store = _require_store(namespace, account)
+        drafts = store.GetDefaultFolder(16)  # olFolderDrafts
+
+        items = drafts.Items
+        # Drafts use LastModificationTime rather than ReceivedTime
+        try:
+            items.Sort("[LastModificationTime]", True)
+        except Exception:
+            # Fallback: some stores reject sort on Drafts; iterate as-is
+            pass
+
+        total = items.Count
+        results = []
+        # Iterate sorted items, honoring offset and limit
+        # items.Item is 1-indexed
+        start = offset + 1
+        end = min(offset + limit, total)
+        for i in range(start, end + 1):
+            try:
+                item = items.Item(i)
+                body = item.Body or ""
+                preview = body[:200]
+                if len(body) > 200:
+                    preview += "..."
+                results.append({
+                    "entry_id": item.EntryID,
+                    "subject": item.Subject or "(no subject)",
+                    "to": item.To or "",
+                    "cc": item.CC or "",
+                    "bcc": item.BCC or "",
+                    "last_modified": str(item.LastModificationTime),
+                    "has_attachments": bool(item.Attachments.Count > 0),
+                    "attachment_count": item.Attachments.Count,
+                    "body_preview": preview,
+                })
+            except Exception:
+                continue
+        return json.dumps(results, indent=2, default=str)
+
+    try:
+        return await bridge.call(_list, limit, offset, account)
+    except Exception as e:
+        return f"Error listing drafts: {format_com_error(e)}"
+
+
+# =====================================================================
+# TOOL 1D: read_draft
+# =====================================================================
+
+@mcp.tool()
+async def read_draft(
+    draft_id: str,
+    account: str = "",
+) -> str:
+    """Read the full content of a specific draft.
+
+    Retrieves complete draft details including the full body, all recipients
+    (To/CC/BCC), attachment file names, and last-modified time. Use this to
+    review a draft before calling send_draft.
+
+    Args:
+        draft_id: The unique Outlook EntryID of the draft. Get this from
+            list_drafts results.
+        account: Optional. Account display name (or substring). Only needed
+            if draft_id is ambiguous across stores.
+
+    Returns:
+        JSON object with full draft details (entry_id, subject, to, cc, bcc,
+        body, html_body, attachments, last_modified, has_attachments).
+    """
+    def _read(outlook, namespace, draft_id, account):
+        if account:
+            store = _require_store(namespace, account)
+            item = namespace.GetItemFromID(draft_id, store.StoreID)
+        else:
+            item = namespace.GetItemFromID(draft_id)
+        if err := _check_item_class(item, _OL_CLASS_MAIL, "mail item"):
+            return err
+
+        attachments = []
+        try:
+            for i in range(item.Attachments.Count):
+                try:
+                    attachments.append(item.Attachments.Item(i + 1).FileName)
+                except Exception:
+                    continue
+        except Exception:
+            pass
+
+        # HTMLBody may be very large; expose it but truncated like Body
+        html_body = ""
+        try:
+            html_body = item.HTMLBody or ""
+        except Exception:
+            html_body = ""
+
+        result = {
+            "entry_id": item.EntryID,
+            "subject": item.Subject or "(no subject)",
+            "to": item.To or "",
+            "cc": item.CC or "",
+            "bcc": item.BCC or "",
+            "body": item.Body or "",
+            "html_body": html_body,
+            "attachments": attachments,
+            "has_attachments": len(attachments) > 0,
+            "attachment_count": len(attachments),
+            "last_modified": str(item.LastModificationTime),
+        }
+        return json.dumps(result, indent=2, default=str)
+
+    try:
+        return await bridge.call(_read, draft_id, account)
+    except Exception as e:
+        return f"Error reading draft: {format_com_error(e)}"
+
+
+# =====================================================================
+# TOOL 1E: send_draft
+# =====================================================================
+
+@mcp.tool()
+async def send_draft(
+    draft_id: str,
+    account: str = "",
+) -> str:
+    """Send an existing draft from Outlook's Drafts folder.
+
+    Looks up the draft by EntryID and calls MailItem.Send() on it. After a
+    successful send, Outlook automatically moves the message from Drafts to
+    Sent Items (this is standard Outlook behavior, not something this tool
+    does explicitly). The EntryID of the message changes when it moves
+    folders, so the returned message_id reflects the post-send location when
+    available.
+
+    Args:
+        draft_id: The unique Outlook EntryID of the draft to send. Get this
+            from list_drafts results.
+        account: Optional. Account display name (or substring). Only needed
+            if draft_id is ambiguous across stores.
+
+    Returns:
+        Confirmation message including the sent subject and recipients, or
+        an error.
+    """
+    def _send(outlook, namespace, draft_id, account):
+        if account:
+            store = _require_store(namespace, account)
+            item = namespace.GetItemFromID(draft_id, store.StoreID)
+        else:
+            item = namespace.GetItemFromID(draft_id)
+        if err := _check_item_class(item, _OL_CLASS_MAIL, "mail item"):
+            return err
+
+        subject = item.Subject or "(no subject)"
+        to = item.To or ""
+        # Send() triggers Outlook to deliver the message and (in standard
+        # Outlook behavior) move it to the Sent Items folder. The original
+        # EntryID is no longer valid afterward — Outlook assigns a new one.
+        item.Send()
+        return json.dumps({
+            "status": "sent",
+            "subject": subject,
+            "to": to,
+            "message": f"Draft sent: '{subject}' to {to}",
+        }, indent=2, default=str)
+
+    try:
+        return await bridge.call(_send, draft_id, account)
+    except Exception as e:
+        return f"Error sending draft: {format_com_error(e)}"
+
+
+# =====================================================================
 # TOOL 2: list_emails
 # =====================================================================
 

--- a/src/outlook_desktop_mcp/server.py
+++ b/src/outlook_desktop_mcp/server.py
@@ -305,6 +305,69 @@ async def send_email(
 
 
 # =====================================================================
+# TOOL 1B: save_draft
+# =====================================================================
+
+@mcp.tool()
+async def save_draft(
+    to: str,
+    subject: str,
+    body: str,
+    cc: str = "",
+    bcc: str = "",
+    html_body: str = "",
+    account: str = "",
+) -> str:
+    """Save an email as a draft in Outlook's Drafts folder without sending.
+
+    Creates an email and stores it in the Drafts folder of the selected account
+    so the user can review, edit, and send it later from Outlook. The message
+    is NOT sent — use send_email for that. This is the recommended tool when a
+    workflow requires human review before delivery.
+
+    Args:
+        to: One or more recipient email addresses, separated by semicolons.
+            Example: "alice@example.com" or "alice@example.com; bob@example.com"
+        subject: The email subject line.
+        body: The plain-text body of the email. If html_body is also provided,
+            both are set and Outlook will prefer the HTML version.
+        cc: Optional. CC recipients, separated by semicolons.
+        bcc: Optional. BCC recipients, separated by semicolons.
+        html_body: Optional. HTML-formatted body. When provided, Outlook renders
+            the email as HTML. The plain-text body serves as fallback.
+        account: Optional. Account display name (or substring) to save under.
+            Default: primary account. Use list_accounts to see available accounts.
+
+    Returns:
+        A confirmation message with subject and recipients, or an error.
+    """
+    def _save(outlook, namespace, to, subject, body, cc, bcc, html_body, account):
+        store = _require_store(namespace, account)
+        mail = outlook.CreateItem(OL_MAIL_ITEM)
+        # Set the sending account so the draft is filed under the correct Drafts folder
+        for acc in outlook.Session.Accounts:
+            if acc.DeliveryStore.StoreID == store.StoreID:
+                mail._oleobj_.Invoke(*(64209, 0, 8, 0, acc))  # SendUsingAccount
+                break
+        mail.To = to
+        mail.Subject = subject
+        mail.Body = body
+        if cc:
+            mail.CC = cc
+        if bcc:
+            mail.BCC = bcc
+        if html_body:
+            mail.HTMLBody = html_body
+        mail.Save()
+        return f"Draft saved: '{subject}' to {to}"
+
+    try:
+        return await bridge.call(_save, to, subject, body, cc, bcc, html_body, account)
+    except Exception as e:
+        return f"Error saving draft: {format_com_error(e)}"
+
+
+# =====================================================================
 # TOOL 2: list_emails
 # =====================================================================
 

--- a/src/outlook_desktop_mcp/server_mac.py
+++ b/src/outlook_desktop_mcp/server_mac.py
@@ -336,6 +336,259 @@ end tell'''
 
 
 # =====================================================================
+# TOOL 1C: list_drafts
+# =====================================================================
+#
+# NOTE on macOS support: AppleScript exposes the "drafts" folder for
+# legacy/IMAP/POP accounts. Modern "New Outlook for Mac" stores Exchange/M365
+# data in the cloud and does not expose drafts through AppleScript — in that
+# case the tool returns an empty list. The Windows COM build is recommended
+# for full draft management.
+
+@mcp.tool()
+async def list_drafts(
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """List drafts currently saved in Outlook's Drafts folder.
+
+    Returns a JSON array of draft summaries sorted by last-modified time
+    (newest first). Each summary includes entry_id, subject, to, cc, bcc,
+    last_modified, has_attachments, and a short body_preview (first ~200
+    chars of the plain-text body).
+
+    Args:
+        limit: Maximum number of drafts to return. Default 50, capped at 200.
+        offset: Number of newest drafts to skip before returning. Default 0.
+
+    Returns:
+        JSON array of draft summary objects.
+    """
+    limit = min(max(1, limit), 200)
+    offset = max(0, offset)
+    end_index = offset + limit  # 1-indexed slice upper bound applied below
+
+    script = f'''tell application "Microsoft Outlook"
+    set folderRef to drafts
+    set allMsgs to messages of folderRef
+    set msgCount to count of allMsgs
+    set startIdx to {offset + 1}
+    set endIdx to {end_index}
+    if endIdx > msgCount then set endIdx to msgCount
+    set output to ""
+    if startIdx > msgCount then return output
+    repeat with i from startIdx to endIdx
+        set m to item i of allMsgs
+        set mid to id of m
+        set msubject to subject of m
+        set mto to ""
+        try
+            set recips to to recipients of m
+            repeat with r in recips
+                set mto to mto & address of r & "; "
+            end repeat
+        end try
+        set mcc to ""
+        try
+            set recips to cc recipients of m
+            repeat with r in recips
+                set mcc to mcc & address of r & "; "
+            end repeat
+        end try
+        set mbcc to ""
+        try
+            set recips to bcc recipients of m
+            repeat with r in recips
+                set mbcc to mbcc & address of r & "; "
+            end repeat
+        end try
+        set mtime to ""
+        try
+            set mtime to (modification date of m) as string
+        end try
+        set mattcount to 0
+        try
+            set mattcount to count of attachments of m
+        end try
+        set mbody to ""
+        try
+            set mbody to plain text content of m
+        end try
+        set output to output & (mid as text) & "{DELIM}" & msubject & "{DELIM}" & mto & "{DELIM}" & mcc & "{DELIM}" & mbcc & "{DELIM}" & mtime & "{DELIM}" & (mattcount as text) & "{DELIM}" & mbody & "{RECORD_DELIM}"
+    end repeat
+    return output
+end tell'''
+
+    try:
+        raw = await bridge.run(script)
+        results = []
+        if raw:
+            for record in raw.split(RECORD_DELIM):
+                record = record.strip()
+                if not record:
+                    continue
+                parts = record.split(DELIM, 7)
+                if len(parts) < 8:
+                    continue
+                att_count = int(parts[6]) if parts[6].strip().isdigit() else 0
+                body = _clean(parts[7])
+                preview = body[:200]
+                if len(body) > 200:
+                    preview += "..."
+                results.append({
+                    "entry_id": parts[0].strip(),
+                    "subject": parts[1].strip() or "(no subject)",
+                    "to": parts[2].strip().rstrip("; "),
+                    "cc": parts[3].strip().rstrip("; "),
+                    "bcc": parts[4].strip().rstrip("; "),
+                    "last_modified": _clean(parts[5]),
+                    "has_attachments": att_count > 0,
+                    "attachment_count": att_count,
+                    "body_preview": preview,
+                })
+        return json.dumps(results, indent=2, default=str)
+    except Exception as e:
+        return f"Error listing drafts: {e}"
+
+
+# =====================================================================
+# TOOL 1D: read_draft
+# =====================================================================
+
+@mcp.tool()
+async def read_draft(draft_id: str) -> str:
+    """Read the full content of a specific draft.
+
+    Retrieves complete draft details including the full body, all recipients
+    (To/CC/BCC), attachment file names, and last-modified time. Use this to
+    review a draft before calling send_draft.
+
+    Args:
+        draft_id: The numeric ID of the draft from list_drafts results.
+
+    Returns:
+        JSON object with full draft details.
+    """
+    script = f'''tell application "Microsoft Outlook"
+    set m to message id {draft_id}
+    set mid to id of m
+    set msubject to subject of m
+    set mto to ""
+    try
+        set recips to to recipients of m
+        repeat with r in recips
+            set mto to mto & address of r & "; "
+        end repeat
+    end try
+    set mcc to ""
+    try
+        set recips to cc recipients of m
+        repeat with r in recips
+            set mcc to mcc & address of r & "; "
+        end repeat
+    end try
+    set mbcc to ""
+    try
+        set recips to bcc recipients of m
+        repeat with r in recips
+            set mbcc to mbcc & address of r & "; "
+        end repeat
+    end try
+    set mtime to ""
+    try
+        set mtime to (modification date of m) as string
+    end try
+    set mattnames to ""
+    try
+        repeat with a in attachments of m
+            set mattnames to mattnames & (name of a) & "; "
+        end repeat
+    end try
+    set mbody to ""
+    try
+        set mbody to plain text content of m
+    end try
+    set mhtml to ""
+    try
+        set mhtml to content of m
+    end try
+    return (mid as text) & "{DELIM}" & msubject & "{DELIM}" & mto & "{DELIM}" & mcc & "{DELIM}" & mbcc & "{DELIM}" & mtime & "{DELIM}" & mattnames & "{DELIM}" & mbody & "{DELIM}" & mhtml
+end tell'''
+
+    try:
+        raw = await bridge.run(script)
+        parts = raw.split(DELIM, 8)
+        if len(parts) < 9:
+            return json.dumps({"error": "Failed to parse draft data"})
+        att_raw = parts[6].strip().rstrip("; ")
+        attachments = [a.strip() for a in att_raw.split(";") if a.strip()] if att_raw else []
+        result = {
+            "entry_id": parts[0].strip(),
+            "subject": parts[1].strip() or "(no subject)",
+            "to": parts[2].strip().rstrip("; "),
+            "cc": parts[3].strip().rstrip("; "),
+            "bcc": parts[4].strip().rstrip("; "),
+            "last_modified": _clean(parts[5]),
+            "attachments": attachments,
+            "has_attachments": len(attachments) > 0,
+            "attachment_count": len(attachments),
+            "body": _clean(parts[7]),
+            "html_body": _clean(parts[8]),
+        }
+        return json.dumps(result, indent=2, default=str)
+    except Exception as e:
+        return f"Error reading draft: {e}"
+
+
+# =====================================================================
+# TOOL 1E: send_draft
+# =====================================================================
+
+@mcp.tool()
+async def send_draft(draft_id: str) -> str:
+    """Send an existing draft from Outlook's Drafts folder.
+
+    Looks up the draft by ID and dispatches it via AppleScript `send`.
+    After a successful send, Outlook moves the message from Drafts to Sent
+    Items automatically (standard Outlook behavior).
+
+    Args:
+        draft_id: The numeric ID of the draft to send. Get this from
+            list_drafts results.
+
+    Returns:
+        JSON object confirming the send, or an error.
+    """
+    script = f'''tell application "Microsoft Outlook"
+    set m to message id {draft_id}
+    set msubject to subject of m
+    set mto to ""
+    try
+        set recips to to recipients of m
+        repeat with r in recips
+            set mto to mto & address of r & "; "
+        end repeat
+    end try
+    send m
+    return msubject & "{DELIM}" & mto
+end tell'''
+
+    try:
+        raw = await bridge.run(script)
+        parts = raw.split(DELIM, 1)
+        subject = parts[0].strip() if parts else ""
+        to = parts[1].strip().rstrip("; ") if len(parts) > 1 else ""
+        return json.dumps({
+            "status": "sent",
+            "subject": subject or "(no subject)",
+            "to": to,
+            "message": f"Draft sent: '{subject}' to {to}",
+        }, indent=2, default=str)
+    except Exception as e:
+        return f"Error sending draft: {e}"
+
+
+# =====================================================================
 # TOOL 2: list_emails
 # =====================================================================
 

--- a/src/outlook_desktop_mcp/server_mac.py
+++ b/src/outlook_desktop_mcp/server_mac.py
@@ -274,6 +274,68 @@ end tell'''
 
 
 # =====================================================================
+# TOOL 1B: save_draft
+# =====================================================================
+
+@mcp.tool()
+async def save_draft(
+    to: str,
+    subject: str,
+    body: str,
+    cc: str = "",
+    bcc: str = "",
+    html_body: str = "",
+) -> str:
+    """Save an email as a draft in Outlook's Drafts folder without sending.
+
+    Creates an outgoing message in Outlook and leaves it in the Drafts folder
+    so the user can review, edit, and send it later from Outlook. The message
+    is NOT sent — use send_email for that. This is the recommended tool when a
+    workflow requires human review before delivery.
+
+    Args:
+        to: One or more recipient email addresses, separated by semicolons.
+            Example: "alice@example.com" or "alice@example.com; bob@example.com"
+        subject: The email subject line.
+        body: The plain-text body of the email. If html_body is also provided,
+            both are set and Outlook will prefer the HTML version.
+        cc: Optional. CC recipients, separated by semicolons.
+        bcc: Optional. BCC recipients, separated by semicolons.
+        html_body: Optional. HTML-formatted body. When provided, Outlook renders
+            the email as HTML. The plain-text body serves as fallback.
+
+    Returns:
+        A confirmation message with subject and recipients, or an error.
+    """
+    # Build recipient lines (same dialect as send_email)
+    def _recipient_lines(addresses: str, kind: str) -> str:
+        lines = ""
+        for addr in addresses.split(";"):
+            addr = addr.strip()
+            if addr:
+                lines += f'make new {kind} at newMsg with properties {{email address:{{address:"{escape(addr)}"}}}}\n'
+        return lines
+
+    to_lines = _recipient_lines(to, "to recipient")
+    cc_lines = _recipient_lines(cc, "cc recipient") if cc else ""
+    bcc_lines = _recipient_lines(bcc, "bcc recipient") if bcc else ""
+
+    content_prop = f'html content:"{escape(html_body)}"' if html_body else f'content:"{escape(body)}"'
+
+    # No `send newMsg` here — the outgoing message stays in Drafts.
+    script = f'''tell application "Microsoft Outlook"
+    set newMsg to make new outgoing message with properties {{subject:"{escape(subject)}", {content_prop}}}
+    {to_lines}{cc_lines}{bcc_lines}
+end tell'''
+
+    try:
+        await bridge.run(script)
+        return f"Draft saved: '{subject}' to {to}"
+    except Exception as e:
+        return f"Error saving draft: {e}"
+
+
+# =====================================================================
 # TOOL 2: list_emails
 # =====================================================================
 


### PR DESCRIPTION
## Summary

Adds 4 new tools to manage Outlook drafts end-to-end, enabling a complete
"agent writes -> human/agent reviews -> agent sends" workflow without
ever using send_email's immediate-delivery path.

- `save_draft` (commit 1) — write a new draft into the Drafts folder (mirrors `send_email`)
- `list_drafts` (commit 2) — list drafts with limit/offset pagination, newest first
- `read_draft` (commit 2) — fetch full body + recipients + attachment names for a specific draft
- `send_draft` (commit 2) — dispatch an existing draft by EntryID (Outlook then moves it to Sent Items)

## Motivation

Several teams adopting this MCP server require a "agent drafts -> human
reviews -> agent or human sends" flow for governance / compliance
reasons. `save_draft` alone gets the message into Drafts but leaves the
agent unable to inspect or release it; the three additional tools close
that loop.

## Implementation

### `save_draft` — TOOL 1B (commit 1)

Same signature as `send_email`. On Windows COM, calls `MailItem.Save()`
instead of `MailItem.Send()`. On macOS AppleScript, omits the trailing
`send newMsg` line so the outgoing message stays in Drafts.

### `list_drafts` — TOOL 1C (commit 2)

Reads `olFolderDrafts (16)` on the selected store and returns a JSON
array sorted by `LastModificationTime` (newest first). Each entry
includes `entry_id`, `subject`, `to`, `cc`, `bcc`, `last_modified`,
`has_attachments`, `attachment_count`, and a ~200-char `body_preview`.
Supports `limit` (default 50, capped at 200) and `offset` for pagination.

### `read_draft` — TOOL 1D (commit 2)

Loads a draft by EntryID via `NameSpace.GetItemFromID` and returns the
full plain-text `body`, the full `html_body`, all recipients (`to` /
`cc` / `bcc`), and an `attachments` array of file names. Validates the
item is a mail item before returning.

### `send_draft` — TOOL 1E (commit 2)

Resolves the draft by EntryID and calls `MailItem.Send()` on Windows
COM (`send m` on macOS). Outlook then moves the message from Drafts to
Sent Items per its standard behavior — no folder move is performed by
this tool. Returns a JSON status object with the dispatched subject and
recipients.

## Notes

- No existing tool is modified. All four new tools are added as `TOOL 1B/1C/1D/1E`
  immediately after `send_email`, keeping the existing tool numbering intact.
- README's Email tools table lists all four new tools; totals bumped to **33 Windows / 26 macOS**.
- Version bumped `0.3.0` -> `0.3.2`.
- Wheel build (`python -m build --wheel`) succeeds locally.
- macOS caveat documented inline: New Outlook for Mac with Exchange accounts may not expose drafts via AppleScript; the Windows COM build is recommended for full draft management.

## Test plan

- [ ] Windows: `save_draft` -> verify message lands in Drafts (not Sent) with all fields populated.
- [ ] Windows: `list_drafts` -> verify it returns drafts newest-first with `body_preview` populated; pagination via `limit` / `offset` works.
- [ ] Windows: `read_draft(draft_id=...)` -> verify full body and attachment names returned.
- [ ] Windows: `send_draft(draft_id=...)` -> verify the message is delivered and moves to Sent Items.
- [ ] Windows: `account=` parameter targets non-default stores correctly for all four tools.
- [ ] macOS: equivalents on Outlook for Mac (legacy / IMAP accounts).
- [ ] Sanity: `send_email` and all 29 pre-existing tools continue to work unchanged.

Happy to iterate on naming / placement / docstring wording.