### PR TITLE
Fix locale-dependent date scrambling in format_date (macOS)

### DIFF
--- a/src/outlook_desktop_mcp/utils/applescript_helpers.py
+++ b/src/outlook_desktop_mcp/utils/applescript_helpers.py
@@ -17,13 +17,34 @@ def escape(text: str) -> str:
 
 
 def format_date(dt: datetime) -> str:
-    """Convert a Python datetime to an AppleScript date string.
+    """Convert a Python datetime to a locale-independent AppleScript date.
 
-    Returns a string like: date "Sunday, March 22, 2026 at 2:00:00 PM"
-    AppleScript parses dates based on the system locale, so we use a
-    locale-friendly format that osascript can interpret.
+    AppleScript's ``date "..."`` string coercion parses the string according
+    to the *system locale*, so handing it an ISO string such as
+    ``date "2026-03-22 14:00:00"`` is mis-read on non-US locales. On es_ES,
+    for example, AppleScript turns that into 16 September 2027 — the date is
+    scrambled while only the time survives.
+
+    To stay locale-independent we build the date by assigning its numeric
+    components (which AppleScript never reinterprets) and wrap the whole thing
+    in ``run script`` so the result is still a single inline expression that
+    can be interpolated everywhere format_date() is used (event properties,
+    ``set start time of e to ...``, task due dates, etc.). The day is reset to
+    1 before setting year/month to avoid end-of-month rollover (e.g. assigning
+    a month while the day is 31).
     """
-    return f'date "{dt.strftime("%Y-%m-%d %H:%M:%S")}"'
+    inner = (
+        "set d to current date\\n"
+        "set day of d to 1\\n"
+        f"set year of d to {dt.year}\\n"
+        f"set month of d to {dt.month}\\n"
+        f"set day of d to {dt.day}\\n"
+        f"set hours of d to {dt.hour}\\n"
+        f"set minutes of d to {dt.minute}\\n"
+        f"set seconds of d to {dt.second}\\n"
+        "d"
+    )
+    return f'(run script "{inner}")'
 
 
 def parse_date(text: str) -> str:

--- a/tests/format_date_test.py
+++ b/tests/format_date_test.py
@@ -1,0 +1,53 @@
+"""
+Unit test for format_date — locale-independent AppleScript date construction.
+
+Pure unit test: no Outlook, no osascript, runs on any platform.
+
+Regression for the locale bug where ``date "2026-03-22 14:00:00"`` was
+mis-parsed by AppleScript on non-US locales (e.g. es_ES -> 16 Sep 2027),
+scrambling the date while preserving only the time. The fix builds the date
+from numeric components via ``run script`` instead of a string literal.
+"""
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from outlook_desktop_mcp.utils.applescript_helpers import format_date  # noqa: E402
+
+
+def test_format_date_uses_numeric_components_not_string_literal():
+    expr = format_date(datetime(2026, 3, 22, 14, 5, 9))
+
+    # Must NOT emit a locale-parsed string-literal date.
+    assert 'date "2026' not in expr
+
+    # Must build the date from numeric components inside run script.
+    assert expr.startswith("(run script ")
+    for fragment in (
+        "set year of d to 2026",
+        "set month of d to 3",
+        "set day of d to 22",
+        "set hours of d to 14",
+        "set minutes of d to 5",
+        "set seconds of d to 9",
+    ):
+        assert fragment in expr, fragment
+
+    # Day is reset to 1 before year/month to avoid end-of-month rollover.
+    assert expr.index("set day of d to 1") < expr.index("set month of d to 3")
+
+
+def test_format_date_is_a_single_inline_expression():
+    # No raw newlines: the result is interpolated inline into larger scripts,
+    # so newlines must be escaped (\\n) for AppleScript's string literal.
+    expr = format_date(datetime(2026, 12, 31, 23, 59, 59))
+    assert "\n" not in expr
+    assert expr.count("(run script ") == 1
+
+
+if __name__ == "__main__":
+    test_format_date_uses_numeric_components_not_string_literal()
+    test_format_date_is_a_single_inline_expression()
+    print("OK")


### PR DESCRIPTION
## Problem

On macOS, every calendar/task date is wrong on non-US locales.

`format_date()` produces an AppleScript **string literal**:

```python
return f'date "{dt.strftime("%Y-%m-%d %H:%M:%S")}"'   # date "2026-03-22 14:00:00"
```

AppleScript's `date "..."` coercion parses the string **according to the system locale**, so the ISO string is mis-read off US. Reproduced live on an `es_ES` Mac:

```
$ osascript -e 'date "2026-03-22 14:00:00"'
date jueves, 16 de septiembre de 2027, 14:00:00     # date scrambled, only time survives
```

This affects `create_event`, `create_meeting`, `update_event`, and the `create_task` `due_date` — all route through `format_date`.

## Fix

Build the date from its **numeric components** (which AppleScript never reinterprets) and wrap it in `run script` so the result is still a single inline expression usable at every existing call site — no changes needed at the call sites:

```
(run script "set d to current date\nset day of d to 1\nset year of d to 2026\nset month of d to 3\nset day of d to 22\nset hours of d to 14\nset minutes of d to 0\nset seconds of d to 0\nd")
```

The day is reset to `1` before setting year/month to avoid end-of-month rollover (assigning a month while the day is 31).

Verified on the same `es_ES` Mac:

```
$ osascript -e '(run script "set d to current date\nset day of d to 1\nset year of d to 2026\nset month of d to 3\nset day of d to 22\nset hours of d to 14\nset minutes of d to 0\nset seconds of d to 0\nd")'
date domingo, 22 de marzo de 2026, 14:00:00         # correct
```

## Tests

Adds `tests/format_date_test.py` — a platform-independent unit test (no Outlook / `osascript` required) asserting the generated expression uses numeric components, resets the day first, and stays a single inline expression.

## Notes

- `parse_date` (the read path) already handles localized strings, so this is purely the write path.
- Windows (`server.py`) is unaffected — it uses COM, not AppleScript date literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)