### PR TITLE
Add save_draft MCP tool and MCP test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Both permissions are one-time setup — macOS remembers them for future sessions
 | Tool | Windows | macOS | Description |
 |------|:-------:|:-----:|-------------|
 | `send_email` | yes | yes | Send an email with To/CC/BCC, plain text or HTML body |
+| `save_draft` | yes | yes | Save an email draft to Drafts without sending |
 | `list_emails` | yes | yes | List recent emails from any folder, with optional unread filter |
 | `read_email` | yes | yes | Read full email content by entry ID or subject search |
 | `search_emails` | yes | yes | Full-text search across email subjects and bodies |
@@ -145,7 +146,7 @@ These tools rely on COM-specific APIs (MAPI property accessors, the Rules object
 | `toggle_rule` | yes | — | Enable or disable a mail rule by name |
 | `get_out_of_office` | yes | — | Check whether Out of Office auto-reply is on or off |
 
-**Total: 29 tools on Windows, 22 tools on macOS.**
+**Total: 30 tools on Windows, 23 tools on macOS.**
 
 ## Architecture Details
 

--- a/src/outlook_desktop_mcp/server.py
+++ b/src/outlook_desktop_mcp/server.py
@@ -304,6 +304,59 @@ async def send_email(
         return f"Error sending email: {format_com_error(e)}"
 
 
+@mcp.tool()
+async def save_draft(
+    to: str,
+    subject: str,
+    body: str,
+    cc: str = "",
+    bcc: str = "",
+    html_body: str = "",
+    account: str = "",
+) -> str:
+    """Save an email to Drafts without sending it.
+
+    Creates a draft email in Outlook's Drafts folder. The message is not sent.
+
+    Args:
+        to: One or more recipient email addresses, separated by semicolons.
+        subject: The email subject line.
+        body: The plain-text body of the email.
+        cc: Optional. CC recipients, separated by semicolons.
+        bcc: Optional. BCC recipients, separated by semicolons.
+        html_body: Optional. HTML-formatted body.
+        account: Optional. Account display name (or substring) to save from.
+            Default: primary account. Use list_accounts to see available accounts.
+
+    Returns:
+        A confirmation message with the draft entry ID, or an error.
+    """
+    def _save(outlook, namespace, to, subject, body, cc, bcc, html_body, account):
+        store = _require_store(namespace, account)
+        mail = outlook.CreateItem(OL_MAIL_ITEM)
+        # Ensure the selected account/store is applied when saving the draft.
+        for acc in outlook.Session.Accounts:
+            if acc.DeliveryStore.StoreID == store.StoreID:
+                mail._oleobj_.Invoke(*(64209, 0, 8, 0, acc))  # SendUsingAccount
+                break
+        mail.To = to
+        mail.Subject = subject
+        mail.Body = body
+        if cc:
+            mail.CC = cc
+        if bcc:
+            mail.BCC = bcc
+        if html_body:
+            mail.HTMLBody = html_body
+        mail.Save()
+        return f"Draft saved: '{subject}' (entry_id={mail.EntryID})"
+
+    try:
+        return await bridge.call(_save, to, subject, body, cc, bcc, html_body, account)
+    except Exception as e:
+        return f"Error saving draft: {format_com_error(e)}"
+
+
 # =====================================================================
 # TOOL 2: list_emails
 # =====================================================================

--- a/src/outlook_desktop_mcp/server_mac.py
+++ b/src/outlook_desktop_mcp/server_mac.py
@@ -273,6 +273,58 @@ end tell'''
         return f"Error sending email: {e}"
 
 
+@mcp.tool()
+async def save_draft(
+    to: str,
+    subject: str,
+    body: str,
+    cc: str = "",
+    bcc: str = "",
+    html_body: str = "",
+) -> str:
+    """Save an email to Drafts without sending it.
+
+    Creates a draft email in Outlook's Drafts folder. The message is not sent.
+
+    Args:
+        to: One or more recipient email addresses, separated by semicolons.
+        subject: The email subject line.
+        body: The plain-text body of the email.
+        cc: Optional. CC recipients, separated by semicolons.
+        bcc: Optional. BCC recipients, separated by semicolons.
+        html_body: Optional. HTML-formatted body. If provided, it is used as
+            the message content.
+
+    Returns:
+        A confirmation message, or an error.
+    """
+    def _recipient_lines(addresses: str, kind: str) -> str:
+        lines = ""
+        for addr in addresses.split(";"):
+            addr = addr.strip()
+            if addr:
+                lines += f'make new {kind} at newMsg with properties {{email address:{{address:"{escape(addr)}"}}}}\n'
+        return lines
+
+    to_lines = _recipient_lines(to, "to recipient")
+    cc_lines = _recipient_lines(cc, "cc recipient") if cc else ""
+    bcc_lines = _recipient_lines(bcc, "bcc recipient") if bcc else ""
+
+    content_prop = f'html content:"{escape(html_body)}"' if html_body else f'content:"{escape(body)}"'
+
+    script = f'''tell application "Microsoft Outlook"
+    set newMsg to make new outgoing message with properties {{subject:"{escape(subject)}", {content_prop}}}
+    {to_lines}{cc_lines}{bcc_lines}
+    save newMsg
+end tell'''
+
+    try:
+        await bridge.run(script)
+        return f"Draft saved: '{subject}'"
+    except Exception as e:
+        return f"Error saving draft: {e}"
+
+
 # =====================================================================
 # TOOL 2: list_emails
 # =====================================================================

--- a/tests/phase3_mcp_test.py
+++ b/tests/phase3_mcp_test.py
@@ -9,6 +9,7 @@ import os
 import json
 import asyncio
 import logging
+from datetime import datetime
 
 # Ensure our package is importable
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
@@ -24,12 +25,13 @@ async def run_tests():
     from mcp.client.stdio import stdio_client, StdioServerParameters
     from mcp.client.session import ClientSession
 
-    python_exe = r"C:\Development_Local\outlook-desktop-mcp\.venv\Scripts\python.exe"
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    python_exe = os.path.join(repo_root, ".venv", "Scripts", "python.exe")
 
     server_params = StdioServerParameters(
         command=python_exe,
         args=["-m", "outlook_desktop_mcp.server"],
-        cwd=r"C:\Development_Local\outlook-desktop-mcp",
+        cwd=repo_root,
     )
 
     log("=" * 60)
@@ -57,7 +59,7 @@ async def run_tests():
                     log(f"    - {t.name}: {desc}")
 
                 expected = [
-                    "send_email", "list_emails", "read_email", "mark_as_read",
+                    "send_email", "save_draft", "list_emails", "read_email", "mark_as_read",
                     "mark_as_unread", "move_email", "reply_email",
                     "list_folders", "search_emails",
                 ]
@@ -67,6 +69,8 @@ async def run_tests():
                 log("  PASS")
             except Exception as e:
                 log(f"  FAIL: {e}")
+
+            draft_subject = f"Outlook Desktop MCP Draft Test {datetime.now().strftime('%Y%m%d%H%M%S')}"
 
             # ----- Test 2: list_folders -----
             total += 1
@@ -134,26 +138,42 @@ async def run_tests():
             except Exception as e:
                 log(f"  FAIL: {e}")
 
-            # ----- Test 6: send_email -----
+            # ----- Test 6: save_draft -----
             total += 1
-            log("\n--- Test 6: send_email ---")
+            log("\n--- Test 6: save_draft ---")
             try:
-                result = await session.call_tool("send_email", {
+                result = await session.call_tool("save_draft", {
                     "to": "user@example.com",
-                    "subject": "Outlook Desktop MCP - Phase 3 MCP Test",
-                    "body": "Sent through the MCP server via stdio. If you see this, the MCP layer works!",
+                    "subject": draft_subject,
+                    "body": "Saved through the MCP server via stdio. This should appear in Drafts.",
                 })
                 content = result.content[0].text
                 log(f"  Result: {content}")
-                assert "sent" in content.lower()
+                assert "draft" in content.lower()
                 passed += 1
                 log("  PASS")
             except Exception as e:
                 log(f"  FAIL: {e}")
 
-            # ----- Test 7: read_email by subject_search -----
+            # ----- Test 7: verify draft appears in Drafts -----
             total += 1
-            log("\n--- Test 7: read_email (by subject_search) ---")
+            log("\n--- Test 7: list_emails (drafts contains saved draft) ---")
+            try:
+                result = await session.call_tool("list_emails", {
+                    "folder": "drafts", "count": 20
+                })
+                drafts = json.loads(result.content[0].text)
+                found = any(d.get("subject") == draft_subject for d in drafts)
+                log(f"  Drafts returned: {len(drafts)}")
+                assert found, f"Draft subject not found in Drafts: {draft_subject}"
+                passed += 1
+                log("  PASS")
+            except Exception as e:
+                log(f"  FAIL: {e}")
+
+            # ----- Test 8: read_email by subject_search -----
+            total += 1
+            log("\n--- Test 8: read_email (by subject_search) ---")
             try:
                 result = await session.call_tool("read_email", {
                     "subject_search": "Feedback", "folder": "inbox"


### PR DESCRIPTION
## Summary
- add new save_draft tool in Windows COM server
- add matching save_draft tool in macOS AppleScript server
- update README email tools table and total tool counts
- extend phase3 MCP test to validate draft creation and Drafts visibility
- make phase3 test server path repo-relative (remove machine-specific paths)

## Validation
- python -m py_compile src/outlook_desktop_mcp/server.py src/outlook_desktop_mcp/server_mac.py tests/phase3_mcp_test.py

## Contributing Flow
- branch created from origin/preview
- PR targets preview
