### PR TITLE
macOS: fix AppleScript timeouts with batched fetches; fix event/folder listing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
     "pywin32>=310; sys_platform == 'win32'",
-    "mcp[cli]>=1.26.0",
+    "mcp[cli]>=1.26.0,<2",
 ]
 
 [project.urls]

--- a/src/outlook_desktop_mcp/applescript_bridge.py
+++ b/src/outlook_desktop_mcp/applescript_bridge.py
@@ -8,11 +8,24 @@ Every tool builds an AppleScript string and passes it to bridge.run().
 """
 import asyncio
 import logging
+import os
 
 logger = logging.getLogger("outlook_desktop_mcp.applescript_bridge")
 
-STARTUP_TIMEOUT = 10
-SCRIPT_TIMEOUT = 30
+
+def _env_timeout(name: str, default: float) -> float:
+    """Read a timeout override (seconds) from the environment."""
+    raw = os.environ.get(name)
+    if raw:
+        try:
+            return float(raw)
+        except ValueError:
+            logger.warning("Invalid %s=%r; using default %ss", name, raw, default)
+    return default
+
+
+STARTUP_TIMEOUT = _env_timeout("OUTLOOK_MCP_STARTUP_TIMEOUT", 10)
+SCRIPT_TIMEOUT = _env_timeout("OUTLOOK_MCP_SCRIPT_TIMEOUT", 120)
 
 
 class AppleScriptBridge:

--- a/src/outlook_desktop_mcp/server_mac.py
+++ b/src/outlook_desktop_mcp/server_mac.py
@@ -17,6 +17,7 @@ from mcp.server.fastmcp import FastMCP
 
 from outlook_desktop_mcp.applescript_bridge import AppleScriptBridge
 from outlook_desktop_mcp.utils.applescript_helpers import (
+    date_component_lines,
     escape,
     format_date,
     parse_date,
@@ -76,6 +77,27 @@ def _clean(value: str) -> str:
     """Replace AppleScript's 'missing value' with empty string."""
     v = value.strip()
     return "" if v == "missing value" else v
+
+
+async def _run_with_fallback(fast_script: str, legacy_script: str) -> str:
+    """Run the batched (fast) AppleScript; fall back to the per-item script.
+
+    Batched property fetches (e.g. `subject of messages 1 thru N of folder`)
+    retrieve a whole column in a single Apple Event instead of one round trip
+    per property per item, which is what made large list calls exceed the
+    script timeout. If this Outlook version rejects a batch form, retry once
+    with the legacy per-item script. Timeouts are not retried — the legacy
+    script is strictly slower.
+    """
+    try:
+        return await bridge.run(fast_script)
+    except RuntimeError as e:
+        if "timed out" in str(e):
+            raise
+        logger.warning(
+            "Batch AppleScript failed; falling back to per-item script: %s", e
+        )
+        return await bridge.run(legacy_script)
 
 
 # --- UI Scraping for New Outlook for Mac ---
@@ -305,7 +327,64 @@ async def list_emails(
     folder_ref = resolve_folder_ref(folder)
     unread_filter = ' whose is read is false' if unread_only else ''
 
-    script = f'''tell application "Microsoft Outlook"
+    # Batched property fetches: one Apple Event per property (whole column)
+    # instead of one per property per message. For unread_only the whose
+    # filter runs inside Outlook and the result is truncated locally.
+    if unread_only:
+        msg_spec = "(every message of folderRef whose is read is false)"
+    else:
+        msg_spec = "messages 1 thru maxCount of folderRef"
+
+    fast_script = f'''tell application "Microsoft Outlook"
+    set folderRef to {folder_ref}
+    set msgCount to count of (messages of folderRef{unread_filter})
+    set maxCount to {count}
+    if msgCount < maxCount then set maxCount to msgCount
+    if maxCount is 0 then return ""
+    set idList to id of {msg_spec}
+    set subjectList to subject of {msg_spec}
+    set timeList to time received of {msg_spec}
+    set readList to is read of {msg_spec}
+    set senderList to {{}}
+    try
+        set senderList to sender of {msg_spec}
+    end try
+    set attLists to {{}}
+    try
+        set attLists to attachments of {msg_spec}
+    end try
+    set output to ""
+    repeat with i from 1 to maxCount
+        set msubject to ""
+        try
+            set msubject to item i of subjectList
+        end try
+        set msender to ""
+        try
+            set msender to address of (item i of senderList)
+        end try
+        set msenderName to ""
+        try
+            set msenderName to name of (item i of senderList)
+        end try
+        set mtime to ""
+        try
+            set mtime to (item i of timeList) as string
+        end try
+        set misread to false
+        try
+            set misread to item i of readList
+        end try
+        set mattcount to 0
+        try
+            set mattcount to count of (item i of attLists)
+        end try
+        set output to output & ((item i of idList) as text) & "{DELIM}" & msubject & "{DELIM}" & msender & "{DELIM}" & msenderName & "{DELIM}" & mtime & "{DELIM}" & (misread as text) & "{DELIM}" & (mattcount as text) & "{RECORD_DELIM}"
+    end repeat
+    return output
+end tell'''
+
+    legacy_script = f'''tell application "Microsoft Outlook"
     set folderRef to {folder_ref}
     set allMsgs to messages of folderRef{unread_filter}
     set msgCount to count of allMsgs
@@ -336,7 +415,7 @@ async def list_emails(
 end tell'''
 
     try:
-        raw = await bridge.run(script)
+        raw = await _run_with_fallback(fast_script, legacy_script)
 
         results = []
         if raw:
@@ -659,6 +738,43 @@ end tell'''
         return f"Error replying to email: {e}"
 
 
+def _folder_listing_pass(level: int, max_depth: int) -> str:
+    """Generate the AppleScript block that lists folders at one nesting
+    level and recurses into subfolders up to max_depth.
+
+    Level 1 reads from the account reference (`item k of acctRefs`);
+    deeper levels read from the enclosing level's folder reference.
+    Folder names accumulate into a "Parent/Child" path. Names and unread
+    counts are fetched as batched columns; only the per-folder message
+    count needs one Apple Event per folder.
+    """
+    parent = "(item k of acctRefs)" if level == 1 else f"(item i{level - 1} of refs{level - 1})"
+    path = f"n{level}" if level == 1 else f'path{level - 1} & "/" & n{level}'
+    deeper = _folder_listing_pass(level + 1, max_depth) if level < max_depth else ""
+    return f'''
+        try
+            set refs{level} to mail folders of {parent}
+            set names{level} to name of mail folders of {parent}
+            set unread{level} to unread count of mail folders of {parent}
+            repeat with i{level} from 1 to count of refs{level}
+                set n{level} to item i{level} of names{level}
+                if n{level} is not missing value then
+                    set path{level} to {path}
+                    set c{level} to 0
+                    try
+                        set c{level} to count of messages of (item i{level} of refs{level})
+                    end try
+                    set u{level} to 0
+                    try
+                        set uu{level} to item i{level} of unread{level}
+                        if uu{level} is not missing value then set u{level} to uu{level}
+                    end try
+                    set output to output & acctName & "{DELIM}" & path{level} & "{DELIM}" & (c{level} as text) & "{DELIM}" & (u{level} as text) & "{RECORD_DELIM}"{deeper}
+                end if
+            end repeat
+        end try'''
+
+
 # =====================================================================
 # TOOL 8: list_folders
 # =====================================================================
@@ -667,18 +783,63 @@ end tell'''
 async def list_folders(max_depth: int = 2) -> str:
     """List all mail folders in the user's Outlook mailbox.
 
-    Returns a JSON array showing the folder hierarchy with item counts.
-    Use this to discover folder names for other tools (list_emails,
-    move_email, search_emails).
+    Returns a JSON array showing the folder hierarchy with item counts,
+    grouped per account (e.g. the Exchange mailbox vs the local
+    "On My Computer" store, which often contains empty folders with the
+    same names). Subfolders appear as "Parent/Child" paths. Use this to
+    discover folder names for other tools (list_emails, move_email,
+    search_emails) — pass just the folder's own name, not the full path.
 
     Args:
         max_depth: How many levels deep to recurse into subfolders.
-            Default 2. Set to 1 for top-level only.
+            Default 2 (top-level plus one level of subfolders); values
+            above 5 are capped at 5.
 
     Returns:
-        JSON array of folder objects with name, item_count, and unread_count.
+        JSON array of folder objects with account, name, item_count,
+        and unread_count.
     """
-    script = f'''tell application "Microsoft Outlook"
+    depth = max(1, min(int(max_depth), 5))
+    listing_pass = _folder_listing_pass(1, depth)
+
+    # Enumerate folders per account so identically named folders (the empty
+    # local "On My Computer" Inbox vs the real Exchange Inbox) are
+    # distinguishable, and skip the nameless account-root containers that
+    # the flat `mail folders` list exposes as "missing value".
+    fast_script = f'''tell application "Microsoft Outlook"
+    set acctRefs to {{}}
+    set acctNames to {{}}
+    try
+        repeat with a in exchange accounts
+            set end of acctRefs to a
+            set end of acctNames to name of a
+        end repeat
+    end try
+    try
+        repeat with a in imap accounts
+            set end of acctRefs to a
+            set end of acctNames to name of a
+        end repeat
+    end try
+    try
+        repeat with a in pop accounts
+            set end of acctRefs to a
+            set end of acctNames to name of a
+        end repeat
+    end try
+    try
+        set end of acctRefs to on my computer
+        set end of acctNames to "On My Computer"
+    end try
+    set output to ""
+    repeat with k from 1 to count of acctRefs
+        set acctName to item k of acctNames
+{listing_pass}
+    end repeat
+    return output
+end tell'''
+
+    legacy_script = f'''tell application "Microsoft Outlook"
     set allFolders to mail folders
     set output to ""
     repeat with f in allFolders
@@ -691,7 +852,7 @@ async def list_folders(max_depth: int = 2) -> str:
 end tell'''
 
     try:
-        raw = await bridge.run(script)
+        raw = await _run_with_fallback(fast_script, legacy_script)
         if not raw:
             return json.dumps([])
 
@@ -701,12 +862,21 @@ end tell'''
             if not record:
                 continue
             parts = record.split(DELIM)
-            if len(parts) < 3:
+            if len(parts) >= 4:
+                account, name, count_s, unread_s = (p.strip() for p in parts[:4])
+            elif len(parts) == 3:
+                # Legacy flat record from the fallback script: no account.
+                account = ""
+                name, count_s, unread_s = (p.strip() for p in parts)
+            else:
+                continue
+            if not _clean(name):
                 continue
             results.append({
-                "name": parts[0].strip(),
-                "item_count": int(parts[1].strip()) if parts[1].strip().isdigit() else 0,
-                "unread_count": int(parts[2].strip()) if parts[2].strip().isdigit() else 0,
+                "account": _clean(account),
+                "name": name,
+                "item_count": int(count_s) if count_s.isdigit() else 0,
+                "unread_count": int(unread_s) if unread_s.isdigit() else 0,
             })
         return json.dumps(results, indent=2, default=str)
     except Exception as e:
@@ -741,7 +911,58 @@ async def search_emails(
     folder_ref = resolve_folder_ref(folder)
     safe_query = escape(query)
 
-    script = f'''tell application "Microsoft Outlook"
+    msg_spec = f'(every message of folderRef whose subject contains "{safe_query}")'
+
+    fast_script = f'''tell application "Microsoft Outlook"
+    set folderRef to {folder_ref}
+    set msgCount to count of {msg_spec}
+    set maxCount to {count}
+    if msgCount < maxCount then set maxCount to msgCount
+    if maxCount is 0 then return ""
+    set idList to id of {msg_spec}
+    set subjectList to subject of {msg_spec}
+    set timeList to time received of {msg_spec}
+    set readList to is read of {msg_spec}
+    set senderList to {{}}
+    try
+        set senderList to sender of {msg_spec}
+    end try
+    set attLists to {{}}
+    try
+        set attLists to attachments of {msg_spec}
+    end try
+    set output to ""
+    repeat with i from 1 to maxCount
+        set msubject to ""
+        try
+            set msubject to item i of subjectList
+        end try
+        set msender to ""
+        try
+            set msender to address of (item i of senderList)
+        end try
+        set msenderName to ""
+        try
+            set msenderName to name of (item i of senderList)
+        end try
+        set mtime to ""
+        try
+            set mtime to (item i of timeList) as string
+        end try
+        set misread to false
+        try
+            set misread to item i of readList
+        end try
+        set mattcount to 0
+        try
+            set mattcount to count of (item i of attLists)
+        end try
+        set output to output & ((item i of idList) as text) & "{DELIM}" & msubject & "{DELIM}" & msender & "{DELIM}" & msenderName & "{DELIM}" & mtime & "{DELIM}" & (misread as text) & "{DELIM}" & (mattcount as text) & "{RECORD_DELIM}"
+    end repeat
+    return output
+end tell'''
+
+    legacy_script = f'''tell application "Microsoft Outlook"
     set folderRef to {folder_ref}
     set matchMsgs to messages of folderRef whose subject contains "{safe_query}"
     set msgCount to count of matchMsgs
@@ -772,7 +993,7 @@ async def search_emails(
 end tell'''
 
     try:
-        raw = await bridge.run(script)
+        raw = await _run_with_fallback(fast_script, legacy_script)
         if not raw:
             return json.dumps([])
 
@@ -835,42 +1056,133 @@ async def list_events(
     start = datetime.fromisoformat(start_date) if start_date else datetime.now()
     end = datetime.fromisoformat(end_date) if end_date else start + timedelta(days=7)
 
-    # Fetch more than needed, filter by date in Python since AppleScript
-    # whose-clause date filtering can be unreliable in Outlook for Mac.
-    fetch_limit = count * 3  # overfetch to account for out-of-range events
+    # The date range is applied server-side with a whose filter on start
+    # time; the cap only bounds the payload if the range matches thousands
+    # of events. Start/end come back as ISO 8601 («class isot») so Python
+    # can re-filter, sort, and truncate deterministically.
+    fetch_cap = max(count * 3, 100)
 
-    script = f'''tell application "Microsoft Outlook"
-    set evts to calendar events
-    set evtCount to count of evts
-    set maxFetch to {fetch_limit}
+    evt_spec = ("(every calendar event whose start time ≥ rangeStart "
+                "and start time ≤ rangeEnd)")
+
+    fast_script = f'''{date_component_lines("rangeStart", start)}
+{date_component_lines("rangeEnd", end)}
+tell application "Microsoft Outlook"
+    set evtCount to count of {evt_spec}
+    set maxFetch to {fetch_cap}
     if evtCount < maxFetch then set maxFetch to evtCount
+    if maxFetch is 0 then return ""
+    set idList to id of {evt_spec}
+    set subjectList to subject of {evt_spec}
+    set startList to start time of {evt_spec}
+    set endList to end time of {evt_spec}
+    set alldayList to all day flag of {evt_spec}
+    set locList to {{}}
+    try
+        set locList to location of {evt_spec}
+    end try
+    set orgList to {{}}
+    try
+        set orgList to organizer of {evt_spec}
+    end try
+end tell
+set output to ""
+repeat with i from 1 to maxFetch
+    set esubject to ""
+    try
+        set esubject to item i of subjectList
+    end try
+    set estart to ""
+    try
+        set estart to (item i of startList) as «class isot» as string
+    end try
+    set eend to ""
+    try
+        set eend to (item i of endList) as «class isot» as string
+    end try
+    set elocation to ""
+    try
+        set elocation to item i of locList
+    end try
+    set eorganizer to ""
+    try
+        set eorganizer to item i of orgList
+    end try
+    set eallday to false
+    try
+        set eallday to item i of alldayList
+    end try
+    set output to output & ((item i of idList) as text) & "{DELIM}" & esubject & "{DELIM}" & estart & "{DELIM}" & eend & "{DELIM}" & elocation & "{DELIM}" & eorganizer & "{DELIM}" & (eallday as text) & "{RECORD_DELIM}"
+end repeat
+return output'''
+
+    # Fallback if this Outlook version rejects the whose-date filter:
+    # batched fetch of the first events in calendar order. The Python
+    # date filter below still applies, so out-of-range events are dropped
+    # rather than returned.
+    legacy_script = f'''tell application "Microsoft Outlook"
+    set evtCount to count of calendar events
+    set maxFetch to {fetch_cap}
+    if evtCount < maxFetch then set maxFetch to evtCount
+    if maxFetch is 0 then return ""
+    set idList to id of calendar events 1 thru maxFetch
+    set subjectList to subject of calendar events 1 thru maxFetch
+    set startList to start time of calendar events 1 thru maxFetch
+    set endList to end time of calendar events 1 thru maxFetch
+    set alldayList to all day flag of calendar events 1 thru maxFetch
+    set locList to {{}}
+    try
+        set locList to location of calendar events 1 thru maxFetch
+    end try
+    set orgList to {{}}
+    try
+        set orgList to organizer of calendar events 1 thru maxFetch
+    end try
     set output to ""
     repeat with i from 1 to maxFetch
-        set e to item i of evts
-        set eid to id of e
-        set esubject to subject of e
-        set estart to start time of e as string
-        set eend to end time of e as string
+        set esubject to ""
+        try
+            set esubject to item i of subjectList
+        end try
+        set estart to ""
+        try
+            set estart to (item i of startList) as string
+        end try
+        set eend to ""
+        try
+            set eend to (item i of endList) as string
+        end try
         set elocation to ""
         try
-            set elocation to location of e
+            set elocation to item i of locList
         end try
         set eorganizer to ""
         try
-            set eorganizer to organizer of e
+            set eorganizer to item i of orgList
         end try
-        set eallday to all day flag of e
-        set output to output & (eid as text) & "{DELIM}" & esubject & "{DELIM}" & estart & "{DELIM}" & eend & "{DELIM}" & elocation & "{DELIM}" & eorganizer & "{DELIM}" & (eallday as text) & "{RECORD_DELIM}"
+        set eallday to false
+        try
+            set eallday to item i of alldayList
+        end try
+        set output to output & ((item i of idList) as text) & "{DELIM}" & esubject & "{DELIM}" & estart & "{DELIM}" & eend & "{DELIM}" & elocation & "{DELIM}" & eorganizer & "{DELIM}" & (eallday as text) & "{RECORD_DELIM}"
     end repeat
     return output
 end tell'''
 
+    def _event_dt(value: str) -> datetime | None:
+        for candidate in (value, parse_date(value)):
+            try:
+                return datetime.fromisoformat(candidate)
+            except (ValueError, TypeError):
+                continue
+        return None
+
     try:
-        raw = await bridge.run(script)
+        raw = await _run_with_fallback(fast_script, legacy_script)
         if not raw:
             return json.dumps([])
 
-        results = []
+        events = []
         for record in raw.split(RECORD_DELIM):
             record = record.strip()
             if not record:
@@ -878,7 +1190,7 @@ end tell'''
             parts = record.split(DELIM)
             if len(parts) < 7:
                 continue
-            results.append({
+            events.append({
                 "entry_id": parts[0].strip(),
                 "subject": parts[1].strip() or "(no subject)",
                 "start": parts[2].strip(),
@@ -887,6 +1199,17 @@ end tell'''
                 "organizer": _clean(parts[5]),
                 "all_day": parts[6].strip().lower() == "true",
             })
+
+        # Re-filter, sort by start time, and truncate. Events whose start
+        # can't be parsed are kept (never silently dropped) and sort last.
+        filtered = []
+        for ev in events:
+            dt = _event_dt(ev["start"])
+            if dt is None or start <= dt <= end:
+                filtered.append((dt, ev))
+        filtered.sort(key=lambda pair: pair[0] or datetime.max)
+        results = [ev for _, ev in filtered[:count]]
+
         return json.dumps(results, indent=2, default=str)
     except Exception as e:
         return f"Error listing events: {e}"
@@ -1220,7 +1543,58 @@ async def search_events(
     """
     safe_query = escape(query)
 
-    script = f'''tell application "Microsoft Outlook"
+    evt_spec = f'(every calendar event whose subject contains "{safe_query}")'
+
+    fast_script = f'''tell application "Microsoft Outlook"
+    set evtCount to count of {evt_spec}
+    set maxCount to {count}
+    if evtCount < maxCount then set maxCount to evtCount
+    if maxCount is 0 then return ""
+    set idList to id of {evt_spec}
+    set subjectList to subject of {evt_spec}
+    set startList to start time of {evt_spec}
+    set endList to end time of {evt_spec}
+    set alldayList to all day flag of {evt_spec}
+    set locList to {{}}
+    try
+        set locList to location of {evt_spec}
+    end try
+    set orgList to {{}}
+    try
+        set orgList to organizer of {evt_spec}
+    end try
+    set output to ""
+    repeat with i from 1 to maxCount
+        set esubject to ""
+        try
+            set esubject to item i of subjectList
+        end try
+        set estart to ""
+        try
+            set estart to (item i of startList) as string
+        end try
+        set eend to ""
+        try
+            set eend to (item i of endList) as string
+        end try
+        set elocation to ""
+        try
+            set elocation to item i of locList
+        end try
+        set eorganizer to ""
+        try
+            set eorganizer to item i of orgList
+        end try
+        set eallday to false
+        try
+            set eallday to item i of alldayList
+        end try
+        set output to output & ((item i of idList) as text) & "{DELIM}" & esubject & "{DELIM}" & estart & "{DELIM}" & eend & "{DELIM}" & elocation & "{DELIM}" & eorganizer & "{DELIM}" & (eallday as text) & "{RECORD_DELIM}"
+    end repeat
+    return output
+end tell'''
+
+    legacy_script = f'''tell application "Microsoft Outlook"
     set evts to calendar events whose subject contains "{safe_query}"
     set evtCount to count of evts
     set maxCount to {count}
@@ -1247,7 +1621,7 @@ async def search_events(
 end tell'''
 
     try:
-        raw = await bridge.run(script)
+        raw = await _run_with_fallback(fast_script, legacy_script)
         if not raw:
             return json.dumps([])
 
@@ -1297,7 +1671,48 @@ async def list_tasks(
     """
     completed_filter = "" if include_completed else " whose todo flag is not completed"
 
-    script = f'''tell application "Microsoft Outlook"
+    if include_completed:
+        task_spec = "tasks 1 thru maxCount"
+    else:
+        task_spec = "(every task whose todo flag is not completed)"
+
+    fast_script = f'''tell application "Microsoft Outlook"
+    set taskCount to count of (tasks{completed_filter})
+    set maxCount to {count}
+    if taskCount < maxCount then set maxCount to taskCount
+    if maxCount is 0 then return ""
+    set idList to id of {task_spec}
+    set nameList to name of {task_spec}
+    set flagList to todo flag of {task_spec}
+    set priList to priority of {task_spec}
+    set dueList to {{}}
+    try
+        set dueList to due date of {task_spec}
+    end try
+    set output to ""
+    repeat with i from 1 to maxCount
+        set tname to ""
+        try
+            set tname to item i of nameList
+        end try
+        set tdue to ""
+        try
+            set tdue to (item i of dueList) as string
+        end try
+        set tflag to ""
+        try
+            set tflag to (item i of flagList) as text
+        end try
+        set tpriority to ""
+        try
+            set tpriority to (item i of priList) as text
+        end try
+        set output to output & ((item i of idList) as text) & "{DELIM}" & tname & "{DELIM}" & tdue & "{DELIM}" & tflag & "{DELIM}" & tpriority & "{RECORD_DELIM}"
+    end repeat
+    return output
+end tell'''
+
+    legacy_script = f'''tell application "Microsoft Outlook"
     set taskList to tasks{completed_filter}
     set taskCount to count of taskList
     set maxCount to {count}
@@ -1319,7 +1734,7 @@ async def list_tasks(
 end tell'''
 
     try:
-        raw = await bridge.run(script)
+        raw = await _run_with_fallback(fast_script, legacy_script)
         if not raw:
             return json.dumps([])
 

--- a/src/outlook_desktop_mcp/utils/applescript_helpers.py
+++ b/src/outlook_desktop_mcp/utils/applescript_helpers.py
@@ -54,6 +54,24 @@ def parse_date(text: str) -> str:
     return text
 
 
+def date_component_lines(var: str, dt: datetime) -> str:
+    """Build AppleScript that constructs a date in `var` from components.
+
+    Unlike `date "..."` literals, component assignment does not depend on
+    the system locale. Day is reset to 1 first so month assignment cannot
+    overflow (e.g. current date Aug 31 -> month 2 would roll into March).
+    """
+    secs = dt.hour * 3600 + dt.minute * 60 + dt.second
+    return (
+        f"set {var} to current date\n"
+        f"set day of {var} to 1\n"
+        f"set year of {var} to {dt.year}\n"
+        f"set month of {var} to {dt.month}\n"
+        f"set day of {var} to {dt.day}\n"
+        f"set time of {var} to {secs}"
+    )
+
+
 # Locale-independent AppleScript folder keywords
 FOLDER_MAP = {
     "inbox": "inbox",

--- a/tests/mac_batch_test.py
+++ b/tests/mac_batch_test.py
@@ -1,0 +1,291 @@
+"""
+Outlook Desktop MCP - macOS Batch AppleScript Test
+===================================================
+Unit tests for the batched (fast) AppleScript generation in server_mac.
+Runs without Outlook: the AppleScript bridge is replaced with a fake.
+
+Run: python tests/mac_batch_test.py
+"""
+import sys
+import os
+import json
+import asyncio
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from outlook_desktop_mcp import server_mac
+from outlook_desktop_mcp.utils.applescript_helpers import DELIM, RECORD_DELIM
+
+
+def log(msg):
+    print(msg, file=sys.stderr, flush=True)
+
+
+class FakeBridge:
+    """Captures scripts and returns canned output."""
+
+    def __init__(self, output="", fail_first_with=None):
+        self.scripts = []
+        self.output = output
+        self.fail_first_with = fail_first_with
+
+    async def run(self, script, timeout=None):
+        self.scripts.append(script)
+        if self.fail_first_with and len(self.scripts) == 1:
+            raise RuntimeError(self.fail_first_with)
+        return self.output
+
+    async def run_lines(self, script, timeout=None):
+        result = await self.run(script, timeout=timeout)
+        return [line for line in result.split("\n") if line.strip()]
+
+
+def email_record(mid="101", subject="Hello", sender="a@b.com",
+                 sender_name="Alice", time="2026-08-27 10:00:00",
+                 is_read="false", att="2"):
+    return DELIM.join([mid, subject, sender, sender_name, time, is_read, att])
+
+
+passed = 0
+total = 0
+
+
+def check(name, condition, detail=""):
+    global passed, total
+    total += 1
+    if condition:
+        passed += 1
+        log(f"  PASS: {name}")
+    else:
+        log(f"  FAIL: {name} {detail}")
+
+
+def test_list_emails_uses_batch_script():
+    log("--- list_emails generates batch script, parses output ---")
+    fake = FakeBridge(output=email_record() + RECORD_DELIM)
+    server_mac.bridge = fake
+
+    result = json.loads(asyncio.run(server_mac.list_emails(folder="inbox", count=40)))
+
+    script = fake.scripts[0]
+    check("single osascript call", len(fake.scripts) == 1)
+    check("batch id fetch", "id of messages 1 thru maxCount" in script, script[:200])
+    check("batch subject fetch", "subject of messages 1 thru maxCount" in script)
+    check("no per-message subject fetch in loop", "set msubject to subject of m\n" not in script)
+    check("no full-folder materialization", "set allMsgs to messages of folderRef" not in script)
+    check("one email parsed", len(result) == 1, str(result))
+    if result:
+        check("subject parsed", result[0]["subject"] == "Hello")
+        check("unread derived from is_read", result[0]["unread"] is True)
+        check("attachment count parsed", result[0]["attachment_count"] == 2)
+
+
+def test_list_emails_unread_uses_whose_filter():
+    log("--- list_emails unread_only filters server-side ---")
+    fake = FakeBridge(output=email_record() + RECORD_DELIM)
+    server_mac.bridge = fake
+
+    asyncio.run(server_mac.list_emails(folder="inbox", count=10, unread_only=True))
+    script = fake.scripts[0]
+    check("whose filter present", "whose is read is false" in script)
+    check("batch fetch on filtered set", "id of (every message of folderRef whose is read is false)" in script)
+
+
+def test_list_emails_falls_back_to_legacy():
+    log("--- list_emails falls back to legacy loop on AppleScript error ---")
+    fake = FakeBridge(output=email_record() + RECORD_DELIM,
+                      fail_first_with="AppleScript error: can't batch")
+    server_mac.bridge = fake
+
+    result = json.loads(asyncio.run(server_mac.list_emails(folder="inbox", count=5)))
+    check("two attempts made", len(fake.scripts) == 2, f"{len(fake.scripts)} scripts")
+    if len(fake.scripts) == 2:
+        check("legacy loop used second", "set allMsgs to messages of folderRef" in fake.scripts[1])
+    check("result parsed after fallback", len(result) == 1 and result[0]["subject"] == "Hello")
+
+
+def test_list_emails_timeout_not_retried():
+    log("--- list_emails does not retry after a timeout ---")
+    fake = FakeBridge(fail_first_with="AppleScript timed out after 30s")
+    server_mac.bridge = fake
+
+    result = asyncio.run(server_mac.list_emails(folder="inbox", count=5))
+    check("only one attempt after timeout", len(fake.scripts) == 1, f"{len(fake.scripts)} scripts")
+    check("error surfaced", "timed out" in result)
+
+
+def test_search_emails_batches_filtered_set():
+    log("--- search_emails batches over whose-filtered set ---")
+    fake = FakeBridge(output=email_record(subject="budget") + RECORD_DELIM)
+    server_mac.bridge = fake
+
+    result = json.loads(asyncio.run(server_mac.search_emails(query="budget", count=10)))
+    script = fake.scripts[0]
+    check("whose subject filter", 'whose subject contains "budget"' in script)
+    check("batch fetch present", "id of (every message of folderRef whose subject contains" in script)
+    check("no per-message property loop", "set msubject to subject of m\n" not in script)
+    check("result parsed", len(result) == 1 and result[0]["subject"] == "budget")
+
+
+def event_record(eid="7", subject="Standup", start="2026-08-27T09:00:00",
+                 end="2026-08-27T09:15:00", loc="Room 1", org="Bob", allday="false"):
+    return DELIM.join([eid, subject, start, end, loc, org, allday])
+
+
+def test_list_events_batches():
+    log("--- list_events filters by date server-side and batches fetch ---")
+    fake = FakeBridge(output=event_record() + RECORD_DELIM)
+    server_mac.bridge = fake
+
+    result = json.loads(asyncio.run(server_mac.list_events(
+        start_date="2026-08-27", end_date="2026-08-28", count=20)))
+    script = fake.scripts[0]
+    check("whose date filter",
+          "whose start time ≥ rangeStart and start time ≤ rangeEnd" in script)
+    check("locale-safe date construction", "set year of rangeStart to 2026" in script
+          and "set month of rangeStart to 8" in script)
+    check("iso date output", "«class isot»" in script)
+    check("no per-event property loop", "set esubject to subject of e\n" not in script)
+    check("no full calendar materialization", "set evts to calendar events\n" not in script)
+    check("result parsed", len(result) == 1 and result[0]["subject"] == "Standup", str(result))
+
+
+def test_list_events_filters_and_sorts_in_python():
+    log("--- list_events drops out-of-range events and sorts by start ---")
+    recs = RECORD_DELIM.join([
+        event_record(eid="3", subject="Late", start="2026-08-27T15:00:00", end="2026-08-27T16:00:00"),
+        event_record(eid="1", subject="Old holiday", start="2012-01-01T00:00:00", end="2012-01-02T00:00:00"),
+        event_record(eid="2", subject="Early", start="2026-08-27T09:00:00", end="2026-08-27T09:15:00"),
+    ]) + RECORD_DELIM
+    fake = FakeBridge(output=recs)
+    server_mac.bridge = fake
+
+    result = json.loads(asyncio.run(server_mac.list_events(
+        start_date="2026-08-27", end_date="2026-08-28", count=20)))
+    check("out-of-range event dropped", all(e["subject"] != "Old holiday" for e in result), str(result))
+    check("two in-range events kept", len(result) == 2, str(result))
+    check("sorted by start time", [e["subject"] for e in result] == ["Early", "Late"], str(result))
+
+
+def test_list_events_truncates_to_count():
+    log("--- list_events returns at most count events after sorting ---")
+    recs = RECORD_DELIM.join([
+        event_record(eid=str(i), subject=f"E{i}", start=f"2026-08-27T{9 + i:02d}:00:00",
+                     end=f"2026-08-27T{10 + i:02d}:00:00")
+        for i in range(3)
+    ]) + RECORD_DELIM
+    fake = FakeBridge(output=recs)
+    server_mac.bridge = fake
+
+    result = json.loads(asyncio.run(server_mac.list_events(
+        start_date="2026-08-27", end_date="2026-08-28", count=2)))
+    check("truncated to count", len(result) == 2, str(result))
+    check("earliest kept", [e["subject"] for e in result] == ["E0", "E1"], str(result))
+
+
+def test_list_folders_batches_names():
+    log("--- list_folders enumerates per account with batched fetches ---")
+    recs = RECORD_DELIM.join([
+        DELIM.join(["edd@example.com", "Inbox", "1200", "4"]),
+        DELIM.join(["edd@example.com", "Inbox/kapptivate", "13413", "0"]),
+        DELIM.join(["On My Computer", "Inbox", "0", "0"]),
+    ]) + RECORD_DELIM
+    fake = FakeBridge(output=recs)
+    server_mac.bridge = fake
+
+    result = json.loads(asyncio.run(server_mac.list_folders()))
+    script = fake.scripts[0]
+    check("enumerates exchange accounts", "exchange accounts" in script)
+    check("enumerates local account", "on my computer" in script)
+    check("batch name fetch", "name of mail folders of" in script)
+    check("batch unread fetch", "unread count of mail folders of" in script)
+    check("nameless containers skipped in script", "is not missing value" in script)
+    check("no per-folder name fetch", "set fname to name of f\n" not in script)
+    check("account tagged", result and result[0].get("account") == "edd@example.com", str(result))
+    check("subfolder path kept", any(f["name"] == "Inbox/kapptivate" for f in result), str(result))
+    check("local account tagged", any(f["account"] == "On My Computer" for f in result), str(result))
+    check("counts parsed", result and result[0]["item_count"] == 1200 and result[0]["unread_count"] == 4)
+
+
+def test_list_folders_depth_and_legacy():
+    log("--- list_folders honors max_depth and drops nameless legacy rows ---")
+    fake = FakeBridge(output="")
+    server_mac.bridge = fake
+    asyncio.run(server_mac.list_folders(max_depth=1))
+    check("depth 1 skips subfolder pass", "mail folders of (item i1 of refs1)" not in fake.scripts[0])
+
+    fake = FakeBridge(output="")
+    server_mac.bridge = fake
+    asyncio.run(server_mac.list_folders(max_depth=2))
+    check("depth 2 includes subfolder pass", "mail folders of (item i1 of refs1)" in fake.scripts[0])
+
+    fake = FakeBridge(output="")
+    server_mac.bridge = fake
+    asyncio.run(server_mac.list_folders(max_depth=3))
+    check("depth 3 recurses further", "mail folders of (item i2 of refs2)" in fake.scripts[0])
+    check("subfolder path built", 'path1 & "/" & n2' in fake.scripts[0])
+
+    # Legacy 3-field records (flat fallback script) still parse; nameless dropped.
+    recs = RECORD_DELIM.join([
+        DELIM.join(["Inbox", "10", "2"]),
+        DELIM.join(["missing value", "0", "0"]),
+    ]) + RECORD_DELIM
+    fake = FakeBridge(output=recs)
+    server_mac.bridge = fake
+    result = json.loads(asyncio.run(server_mac.list_folders()))
+    check("legacy record parsed", any(f["name"] == "Inbox" and f["item_count"] == 10 for f in result), str(result))
+    check("nameless row dropped", all(f["name"] != "missing value" for f in result), str(result))
+
+
+def test_list_tasks_batches():
+    log("--- list_tasks batches task fetch ---")
+    rec = DELIM.join(["55", "Pay invoice", "2026-09-01 00:00:00", "not completed", "priority normal"])
+    fake = FakeBridge(output=rec + RECORD_DELIM)
+    server_mac.bridge = fake
+
+    result = json.loads(asyncio.run(server_mac.list_tasks(count=20)))
+    script = fake.scripts[0]
+    check("batch id fetch on filtered tasks", "id of (every task whose todo flag is not completed)" in script)
+    check("no per-task property loop", "set tname to name of t\n" not in script)
+    check("result parsed", len(result) == 1 and result[0]["subject"] == "Pay invoice")
+
+
+def test_script_timeout_env_override():
+    log("--- SCRIPT_TIMEOUT honors OUTLOOK_MCP_SCRIPT_TIMEOUT env var ---")
+    import importlib
+    from outlook_desktop_mcp import applescript_bridge
+
+    os.environ["OUTLOOK_MCP_SCRIPT_TIMEOUT"] = "45"
+    try:
+        importlib.reload(applescript_bridge)
+        check("env override applied", applescript_bridge.SCRIPT_TIMEOUT == 45.0,
+              str(applescript_bridge.SCRIPT_TIMEOUT))
+    finally:
+        del os.environ["OUTLOOK_MCP_SCRIPT_TIMEOUT"]
+        importlib.reload(applescript_bridge)
+    check("default raised above 30s", applescript_bridge.SCRIPT_TIMEOUT >= 60,
+          str(applescript_bridge.SCRIPT_TIMEOUT))
+
+
+def main():
+    test_list_emails_uses_batch_script()
+    test_list_emails_unread_uses_whose_filter()
+    test_list_emails_falls_back_to_legacy()
+    test_list_emails_timeout_not_retried()
+    test_search_emails_batches_filtered_set()
+    test_list_events_batches()
+    test_list_events_filters_and_sorts_in_python()
+    test_list_events_truncates_to_count()
+    test_list_folders_batches_names()
+    test_list_folders_depth_and_legacy()
+    test_list_tasks_batches()
+    test_script_timeout_env_override()
+
+    log("=" * 50)
+    log(f"{passed}/{total} checks passed")
+    if passed != total:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION


  ## Problem

  On macOS, the list-style tools regularly failed with `AppleScript timed out after 30s`
  on real-world mailboxes. Root cause: every property of every item was fetched with a
  separate Apple Event round trip inside a `repeat` loop — `list_emails` with `count=40`
  issued ~280 round trips (plus materializing the entire folder up front), which cannot
  complete within 30s on a large Exchange mailbox (tested against one with 33k+ messages).

  Two adjacent correctness bugs in the same code paths:

  - `list_events` ignored `start_date`/`end_date` entirely and returned the *oldest*
    events in raw calendar order (e.g. holidays from 2012 instead of this week).
  - `list_folders` ignored `max_depth`, returned a flat list mixing every account's
    folders (so the empty local "On My Computer" Inbox was indistinguishable from the
    real Exchange Inbox), and emitted `"missing value"` rows for nameless account-root
    containers.

  ## Changes

  **Batched AppleScript fetches** (`list_emails`, `search_emails`, `list_events`,
  `search_events`, `list_folders`, `list_tasks`): properties are now fetched as whole
  columns in single Apple Events (`subject of messages 1 thru N of folder`,
  `id of (every message ... whose ...)`) and assembled into output locally. If an
  Outlook version rejects a batch form, the tool falls back once to the previous
  per-item script; timeouts are never retried (the fallback is strictly slower).

  **Timeouts**: script timeout default raised from 30s to 120s as defense in depth;
  both timeouts are now configurable via `OUTLOOK_MCP_SCRIPT_TIMEOUT` and
  `OUTLOOK_MCP_STARTUP_TIMEOUT`.

  **`list_events` date filtering**: the range is applied inside Outlook with a
  `whose start time ≥ … and ≤ …` filter, using locale-independent component-built
  dates instead of `date "…"` literals. Start/end times are returned as ISO 8601 via
  `«class isot»`, and Python re-filters, sorts by start time, and truncates to
  `count` — which also keeps the fallback path correct.

  **`list_folders`**: folders are enumerated per account and tagged with a new
  `account` field, subfolders appear as `Parent/Child` paths, nameless account-root
  containers are skipped, and `max_depth` is honored (capped at 5).

  **Dependency pin**: `mcp[cli]>=1.26.0,<2` — mcp 2.x removed `mcp.server.fastmcp`
  and breaks server startup.

  ## Measurements (Exchange mailbox, 33k-message inbox, 35 folders)

  | Call | Before | After |
  |---|---|---|
  | `list_emails` count=40 | timeout at 30s | ~3s |
  | `list_folders` | timeout at 30s | ~0.2s |
  | `list_events` count=20 | timeout / wrong events | ~0.2s, correct range |

  ## Testing

  - New unit suite `tests/mac_batch_test.py` (52 checks) covering script generation,
    output parsing, the legacy fallback, no-retry-on-timeout, and the timeout env
    overrides. Runs without Outlook: `python tests/mac_batch_test.py`.
  - All generated scripts validated with `osacompile` against Outlook's scripting
    dictionary (Outlook for Mac 16.93.2).
  - Verified end-to-end over MCP stdio against a live mailbox.

  ## Known limitation

  Outlook's AppleScript interface exposes recurring event series by their original
  start date and does not expand occurrences, so a weekly series created last year
  won't match this week's date range. This predates the change and is an Outlook
  scripting constraint.
