### PR TITLE
Fix locale-dependent date filter misparsing on Windows/COM path

### DIFF
--- a/src/outlook_desktop_mcp/server.py
+++ b/src/outlook_desktop_mcp/server.py
@@ -15,7 +15,7 @@ import re
 from mcp.server.fastmcp import FastMCP
 
 from outlook_desktop_mcp.com_bridge import OutlookBridge
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import os
 
@@ -359,13 +359,13 @@ async def list_emails(
             restrictions.append("[UnRead] = True")
         if start_date:
             start = _parse_date(start_date)
-            restrictions.append(f"[ReceivedTime] >= '{start.strftime('%m/%d/%Y %H:%M')}'")
+            restrictions.append(f"[ReceivedTime] >= '{_outlook_date_literal(start)}'")
         if end_date:
             end = _parse_date(end_date)
-            restrictions.append(f"[ReceivedTime] <= '{end.strftime('%m/%d/%Y %H:%M')}'")
+            restrictions.append(f"[ReceivedTime] <= '{_outlook_date_literal(end)}'")
         elif start_date:
             # Default end to now when start is specified
-            restrictions.append(f"[ReceivedTime] <= '{datetime.now().strftime('%m/%d/%Y %H:%M')}'")
+            restrictions.append(f"[ReceivedTime] <= '{_outlook_date_literal(datetime.now())}'")
 
         if restrictions:
             items = items.Restrict(" AND ".join(restrictions))
@@ -749,16 +749,16 @@ async def search_emails(
         if start_date:
             start = _parse_date(start_date)
             dasl_parts.append(
-                f"\"urn:schemas:httpmail:datereceived\" >= '{start.strftime('%m/%d/%Y %H:%M')}'"
+                f"\"urn:schemas:httpmail:datereceived\" >= '{_outlook_dasl_date_literal(start)}'"
             )
         if end_date:
             end = _parse_date(end_date)
             dasl_parts.append(
-                f"\"urn:schemas:httpmail:datereceived\" <= '{end.strftime('%m/%d/%Y %H:%M')}'"
+                f"\"urn:schemas:httpmail:datereceived\" <= '{_outlook_dasl_date_literal(end)}'"
             )
         elif start_date:
             dasl_parts.append(
-                f"\"urn:schemas:httpmail:datereceived\" <= '{datetime.now().strftime('%m/%d/%Y %H:%M')}'"
+                f"\"urn:schemas:httpmail:datereceived\" <= '{_outlook_dasl_date_literal(datetime.now())}'"
             )
 
         filter_str = "@SQL=" + " AND ".join(dasl_parts)
@@ -790,6 +790,81 @@ async def search_emails(
 def _parse_date(date_str: str) -> datetime:
     """Parse ISO 8601 date string like '2026-02-25 14:00' or '2026-02-25T14:00:00'."""
     return datetime.fromisoformat(date_str)
+
+
+# --- Helper: locale-safe date literals for Outlook Restrict()/DASL filters ---
+
+# Win32 constants for GetDateFormatW / GetTimeFormatW. win32con does not
+# reliably export these, so define them here.
+_LOCALE_USER_DEFAULT = 0x0400
+_DATE_SHORTDATE = 0x00000001
+_TIME_NOSECONDS = 0x00000002
+
+
+def _format_locale_datetime(dt: datetime) -> str:
+    """Format ``dt`` (a naive wall-clock time) in the Windows user locale's
+    short-date + time format, without seconds.
+
+    Calls GetDateFormatW / GetTimeFormatW directly via ctypes with a
+    ``SYSTEMTIME`` filled from ``dt``'s fields, so no time-zone conversion is
+    applied. (A ``datetime`` handed to pywin32's ``win32api.GetDateFormat`` is
+    silently shifted between local time and UTC, which is why the Win32 API is
+    called here instead.) Windows-only.
+    """
+    import ctypes
+
+    class _SYSTEMTIME(ctypes.Structure):
+        _fields_ = [(name, ctypes.c_uint16) for name in (
+            "wYear", "wMonth", "wDayOfWeek", "wDay",
+            "wHour", "wMinute", "wSecond", "wMilliseconds",
+        )]
+
+    st = _SYSTEMTIME()
+    st.wYear, st.wMonth, st.wDay = dt.year, dt.month, dt.day
+    st.wHour, st.wMinute = dt.hour, dt.minute
+
+    kernel32 = ctypes.windll.kernel32
+    buf = ctypes.create_unicode_buffer(160)
+
+    def _fmt(func, flags):
+        if not func(_LOCALE_USER_DEFAULT, flags, ctypes.byref(st), None,
+                    buf, len(buf)):
+            raise ctypes.WinError()
+        return buf.value
+
+    date_str = _fmt(kernel32.GetDateFormatW, _DATE_SHORTDATE)
+    time_str = _fmt(kernel32.GetTimeFormatW, _TIME_NOSECONDS)
+    return f"{date_str} {time_str}"
+
+
+def _outlook_date_literal(dt: datetime) -> str:
+    """Date literal for a Jet Restrict() filter (``[ReceivedTime]``, ``[Start]``).
+
+    Outlook parses the literal using the Windows regional short-date and time
+    settings (see MS docs, "Filtering Items Using a Date-time Comparison"). A
+    hard-coded ``strftime('%m/%d/%Y')`` literal such as ``'09/07/2026'`` is
+    therefore read as 9 Jul, not 7 Sep, on a day-first (DD/MM/YYYY) locale --
+    day and month are silently swapped and the filter returns wrong or empty
+    results without raising an error. Formatting the literal with the same
+    regional settings the parser uses makes it round-trip on every locale;
+    this mirrors the VBA ``Format(dt, "General Date")`` the docs recommend.
+
+    Jet filters evaluate the literal as local time, so ``dt`` (local) is
+    formatted as-is.
+    """
+    return _format_locale_datetime(dt)
+
+
+def _outlook_dasl_date_literal(dt: datetime) -> str:
+    """Date literal for a DASL Restrict() filter (a property referenced by
+    namespace, e.g. ``urn:schemas:httpmail:datereceived``).
+
+    Same locale formatting as :func:`_outlook_date_literal`, but DASL filters
+    evaluate the literal as UTC (unlike Jet filters, which use local time), so
+    ``dt`` is converted to UTC first. A naive ``dt`` is treated as local time.
+    """
+    utc = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return _format_locale_datetime(utc)
 
 
 # =====================================================================
@@ -838,8 +913,8 @@ async def list_events(
         end = _parse_date(end_date) if end_date else start + timedelta(days=7)
 
         restrict = (
-            f"[Start] >= '{start.strftime('%m/%d/%Y %H:%M')}' "
-            f"AND [Start] <= '{end.strftime('%m/%d/%Y %H:%M')}'"
+            f"[Start] >= '{_outlook_date_literal(start)}' "
+            f"AND [Start] <= '{_outlook_date_literal(end)}'"
         )
         filtered = items.Restrict(restrict)
 
@@ -1275,8 +1350,8 @@ async def search_events(
         end = _parse_date(end_date) if end_date else datetime.now() + timedelta(days=30)
 
         restrict = (
-            f"[Start] >= '{start.strftime('%m/%d/%Y %H:%M')}' "
-            f"AND [Start] <= '{end.strftime('%m/%d/%Y %H:%M')}'"
+            f"[Start] >= '{_outlook_date_literal(start)}' "
+            f"AND [Start] <= '{_outlook_date_literal(end)}'"
         )
         filtered = items.Restrict(restrict)
 

--- a/tests/date_literal_test.py
+++ b/tests/date_literal_test.py
@@ -1,0 +1,98 @@
+"""
+Unit test for _outlook_date_literal / _outlook_dasl_date_literal — locale-safe
+date literals for Outlook Restrict()/DASL filters.
+
+Pure unit test: no Outlook, no pywin32, runs on any platform. The Windows-only
+locale formatter (_format_locale_datetime) is replaced with a fake that
+emulates a day-first (DD/MM/YYYY) regional setting, so the test checks the
+literal-building logic without a Windows machine.
+
+Regression for the locale bug where a hard-coded strftime('%m/%d/%Y %H:%M')
+literal such as '09/07/2026 20:15' was parsed by Outlook as 9 Jul instead of
+7 Sep on non-US locales, silently returning wrong or empty filter results
+(issue #30).
+
+Run: .venv\\Scripts\\python tests\\date_literal_test.py
+"""
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from outlook_desktop_mcp import server  # noqa: E402
+
+# Record every datetime the literal builders hand to the locale formatter, and
+# return a deterministic day-first rendering instead of calling Win32.
+_formatted = []
+
+
+def _fake_format_locale_datetime(dt):
+    _formatted.append(dt)
+    return f"{dt.day:02d}/{dt.month:02d}/{dt.year:04d} {dt.hour:02d}:{dt.minute:02d}"
+
+
+server._format_locale_datetime = _fake_format_locale_datetime
+
+_outlook_date_literal = server._outlook_date_literal
+_outlook_dasl_date_literal = server._outlook_dasl_date_literal
+
+
+def test_jet_literal_passes_local_wall_clock_through_unchanged():
+    """Jet filters compare in local time: the datetime must reach the locale
+    formatter with its wall-clock fields untouched (no tz shift)."""
+    _formatted.clear()
+    out = _outlook_date_literal(datetime(2026, 9, 7, 20, 15))
+    assert out == "07/09/2026 20:15", out
+    assert _formatted == [datetime(2026, 9, 7, 20, 15)], _formatted
+
+
+def test_literal_ordering_comes_from_the_locale_not_the_code():
+    """The builder imposes no day/month order of its own — the fake locale is
+    day-first, so 7 September stays day-first and never renders as 9 July."""
+    out = _outlook_date_literal(datetime(2026, 9, 7, 20, 15))
+    assert out.startswith("07/09/2026")
+    assert "07" == out.split("/")[0]
+
+
+def test_no_month_name_is_spliced_into_the_literal():
+    """Regression: the earlier fix spliced a fixed English abbreviation
+    ('07-Sep-2026') into the literal, which is itself locale-dependent. The
+    builder must add no month name of its own."""
+    english_abbr = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ]
+    for month in range(1, 13):
+        out = _outlook_date_literal(datetime(2026, month, 15, 12, 0))
+        for abbr in english_abbr:
+            assert abbr not in out, (month, out)
+
+
+def test_dasl_literal_is_converted_to_utc():
+    """DASL filters compare in UTC. An aware datetime at +02:00 must reach the
+    formatter shifted back to UTC (18:15), while the Jet path keeps 20:15."""
+    _formatted.clear()
+    aware = datetime(2026, 9, 7, 20, 15, tzinfo=timezone(timedelta(hours=2)))
+
+    assert _outlook_dasl_date_literal(aware) == "07/09/2026 18:15"
+    assert _formatted[-1] == datetime(2026, 9, 7, 18, 15)
+
+    assert _outlook_date_literal(aware.replace(tzinfo=None)) == "07/09/2026 20:15"
+
+
+def test_dasl_literal_leaves_utc_input_unchanged():
+    """A datetime already in UTC is not shifted again."""
+    _formatted.clear()
+    aware_utc = datetime(2026, 9, 7, 20, 15, tzinfo=timezone.utc)
+    assert _outlook_dasl_date_literal(aware_utc) == "07/09/2026 20:15"
+    assert _formatted[-1] == datetime(2026, 9, 7, 20, 15)
+
+
+if __name__ == "__main__":
+    test_jet_literal_passes_local_wall_clock_through_unchanged()
+    test_literal_ordering_comes_from_the_locale_not_the_code()
+    test_no_month_name_is_spliced_into_the_literal()
+    test_dasl_literal_is_converted_to_utc()
+    test_dasl_literal_leaves_utc_input_unchanged()
+    print("OK")


### PR DESCRIPTION
## Problem

`list_emails`, `search_emails`, `list_events` and `search_events` build their `Items.Restrict()` / DASL date filters from `dt.strftime('%m/%d/%Y %H:%M')`, e.g. `09/07/2026 20:15`. Outlook parses that literal using the Windows regional short-date and time settings, which are day-first on most non-US locales. On such a machine `09/07/2026` is read as 9 July, not 7 September — any date where day and month are both <= 12 is silently swapped and the filter returns wrong or empty results without raising an error. Same issue as #30 (still open).

## Fix

Format each filter literal with the same regional settings Outlook's parser reads it back with, so it round-trips on every locale (the approach the docs recommend via `Format(dt, "General Date")`):

- `_format_locale_datetime()` calls `GetDateFormatW` / `GetTimeFormatW` for `LOCALE_USER_DEFAULT` — short date plus time, no seconds (Outlook ignores seconds and the filter misbehaves if the literal carries them). It goes through `ctypes` with a `SYSTEMTIME` built from the datetime's fields; passing a `datetime` to `win32api.GetDateFormat` shifts it between local time and UTC during marshalling (e.g. `20:15` came back as `17:15` on a UTC+3 box).
- `_outlook_date_literal()` — for the three Jet filters (`[ReceivedTime]`, `[Start]`), which compare in local time.
- `_outlook_dasl_date_literal()` — for the `search_emails` DASL filter (`urn:schemas:httpmail:datereceived`), which compares in UTC; the bound is converted to UTC first. This also fixes a pre-existing offset error on that path that was independent of locale.

## Tests

`tests/date_literal_test.py` — platform-independent, no Outlook or pywin32. Stubs the Windows-only formatter and checks the literal-building logic: local wall-clock passes through unchanged for the Jet path, is converted to UTC for the DASL path, and no month name is spliced into the literal.

Verified live on a day-first (UTC+3) Windows locale with Outlook running (`outlook-desktop-mcp.cmd test`, `tests/phase3_mcp_test.py`, and all four tools over a September range): the branch returns September items where the released build returns the wrong month, nothing, or an error — including a tight +/-1h window on `search_emails` that the released build misses by the UTC offset.

## Notes

#25 fixes the same class of bug on the macOS / AppleScript path and notes there that the Windows path is unaffected because it uses COM rather than AppleScript date literals. The COM path has no AppleScript literals, but its `Restrict()` / DASL filter string was locale-dependent in the same way.
